### PR TITLE
Registrationmarks

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -13,6 +13,7 @@ Resources
  * https://github.com/vishnubob/silhouette/blob/master/src/gpgl.py
  * https://github.com/jnweiger/robocut/blob/master/Plotter.cpp#L344-L586
  * https://github.com/fablabnbg/inkscape-silhouette/blob/master/silhouette/Graphtec.py#L305-L419
+ * https://github.com/Skrupellos/silhouette/blob/master/decode
 
 Typical sequence
 ----------------

--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ Troubleshooting
 
 If this reports no usb.core.Device to you, please help troubleshoot.
 
+Using of registration marks
+---------------------------
+
+To plot with registration marks do the following:
+
+1. Open the document examples/registration-marks.svg
+2. Insert your cutting paths and graphics on the apropriate layers.
+3. Printout the whole document including registration marks. You probably want to hide the cutting layer. 
+4. Select your cutting paths in the document, but exclude regmarks and graphics.
+5. Set or ensure the correct values (regmark position/width/height) on the regmark tab.
+6. Enable 'Document has registration marks' and 'Search for registration marks'
+7. Start cut.
+
+The plotter will search the registration marks at the given positions. If it founds the marks, they will serve as accurate reference and define the origin. Therefore it is necessary to set the correct offset values of the mark. As a result the cut will go precisely along the graphics.
+At my device there seems to be a little offset between the search optics and the cutting knife. For enhanced precision I have to set an offset of 0,1mm for both x and y on the first tab to compensate.
 
 Features
 --------

--- a/examples/registration-marks-a4-maxi.svg
+++ b/examples/registration-marks-a4-maxi.svg
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="registration-marks-a4-maxi.svg">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="-23.404105"
+     inkscape:cy="859.94261"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:snap-grids="true"
+     inkscape:snap-page="true"
+     units="mm">
+    <inkscape:grid
+       originy="297mm"
+       spacingy="1mm"
+       spacingx="1mm"
+       units="mm"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="5"
+       id="grid4328"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Regmarks">
+    <rect
+       inkscape:label="regmark-tl"
+       y="24.803152"
+       x="21.25989"
+       height="17.716536"
+       width="17.716536"
+       id="regmark-tl"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.77165353;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:label="regmark-tr"
+       inkscape:connector-curvature="0"
+       id="regmark-tr"
+       d="m 651.9685,24.803145 70.86614,0 0,70.866146"
+       style="fill:none;stroke:#000000;stroke-width:1.77165353;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:label="regmark-bl"
+       inkscape:connector-curvature="0"
+       id="regmark-bl"
+       d="m 92.126034,1031.1024 -70.866144,0 0,-70.86627"
+       style="fill:none;stroke:#000000;stroke-width:1.77165353;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <text
+       inkscape:transform-center-y="-18.071825"
+       inkscape:transform-center-x="85.006143"
+       transform="matrix(0,-1,1,0,0,0)"
+       sodipodi:linespacing="125%"
+       id="text4330"
+       y="21.25989"
+       x="-460.62988"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Arial MT';-inkscape-font-specification:'Arial MT';letter-spacing:0px;word-spacing:0px;fill:#808080;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         style="font-size:12px;fill:#808080;fill-opacity:1"
+         y="21.25989"
+         x="-460.62988"
+         sodipodi:role="line"
+         id="tspan4378">284mm</tspan></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text4334"
+       y="24.803152"
+       x="425.19711"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Arial MT';-inkscape-font-specification:'Arial MT';letter-spacing:0px;word-spacing:0px;fill:#808080;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         style="font-size:12px;fill:#808080;fill-opacity:1"
+         y="24.803152"
+         x="425.19711"
+         sodipodi:role="line"
+         id="tspan4011">198mm</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path2998"
+       d="m 386.11192,34.889128 0,-17.716535 -7.08661,0 14.17323,-10.6299217 14.17323,10.6299217 -7.08662,0 0,17.716535 z"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3237"
+       d="m -17.716535,-2.2107222e-5 35.43307,0"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3239"
+       d="M 0,17.716513 0,-17.716558"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4334-5"
+       y="37.624386"
+       x="-42.970066"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Arial MT';-inkscape-font-specification:'Arial MT';letter-spacing:0px;word-spacing:0px;display:inline;fill:#808080;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         style="font-size:12px;fill:#808080;fill-opacity:1"
+         y="37.624386"
+         x="-42.970066"
+         id="tspan4336-3"
+         sodipodi:role="line">6mm</tspan></text>
+    <text
+       inkscape:transform-center-y="-18.071825"
+       inkscape:transform-center-x="85.006143"
+       transform="matrix(0,-1,1,0,0,0)"
+       sodipodi:linespacing="125%"
+       id="text4330-5"
+       y="30.538059"
+       x="5.516973"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Arial MT';-inkscape-font-specification:'Arial MT';letter-spacing:0px;word-spacing:0px;display:inline;fill:#808080;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         style="font-size:12px;fill:#808080;fill-opacity:1"
+         y="30.538059"
+         x="5.516973"
+         sodipodi:role="line"
+         id="tspan4007">7mm</tspan></text>
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Print"
+     id="layer3"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:inline"
+     inkscape:label="Plot"
+     id="layer2"
+     inkscape:groupmode="layer" />
+</svg>

--- a/examples/registration-marks.svg
+++ b/examples/registration-marks.svg
@@ -14,9 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.48.4 r9939"
-   sodipodi:docname="Silhouette-Passermarken.svg">
-  <defs
-     id="defs4" />
+   sodipodi:docname="registration-marks.svg">
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -24,9 +22,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.7"
-     inkscape:cx="145.62755"
-     inkscape:cy="591.92317"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="206.09891"
+     inkscape:cy="105.01378"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -39,17 +37,19 @@
      inkscape:snap-page="true"
      units="mm">
     <inkscape:grid
-       type="xygrid"
-       id="grid4328"
-       empspacing="5"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true"
-       units="mm"
-       spacingx="1mm"
+       originy="297mm"
        spacingy="1mm"
-       originy="297mm" />
+       spacingx="1mm"
+       units="mm"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="5"
+       id="grid4328"
+       type="xygrid" />
   </sodipodi:namedview>
+  <defs
+     id="defs4" />
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -58,62 +58,113 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Ebene 1"
+     style="display:inline"
+     id="layer1"
      inkscape:groupmode="layer"
-     id="layer1">
+     inkscape:label="Regmarks">
     <rect
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.77165353;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="rect2985"
-       width="17.716536"
+       inkscape:label="regmark-tl"
+       y="70.866119"
+       x="53.149605"
        height="17.716536"
-       x="54.035435"
-       y="71.751846" />
+       width="17.716536"
+       id="regmark-tl"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.77165354;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:3.54330707;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:label="regmark-tr"
+       inkscape:connector-curvature="0"
+       id="regmark-tr"
        d="m 620.07874,70.866114 70.86614,0 0,70.866146"
-       id="path3755"
-       inkscape:connector-curvature="0" />
+       style="fill:none;stroke:#000000;stroke-width:1.77165353;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:3.54330707;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 125.7874,884.0551 -70.86614,0 0,-70.86614"
-       id="path3755-5"
-       inkscape:connector-curvature="0" />
+       inkscape:label="regmark-bl"
+       inkscape:connector-curvature="0"
+       id="regmark-bl"
+       d="m 124.01575,885.82675 -70.866144,0 0,-70.86614"
+       style="fill:none;stroke:#000000;stroke-width:1.77165353;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <text
-       xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Arial MT;-inkscape-font-specification:Arial MT"
-       x="-513.77948"
-       y="70.866142"
-       id="text4330"
-       sodipodi:linespacing="125%"
-       transform="matrix(0,-1,1,0,0,0)"
+       inkscape:transform-center-y="-18.071825"
        inkscape:transform-center-x="85.006143"
-       inkscape:transform-center-y="-18.071825"><tspan
-         sodipodi:role="line"
-         id="tspan4332"
+       transform="matrix(0,-1,1,0,0,0)"
+       sodipodi:linespacing="125%"
+       id="text4330"
+       y="53.149605"
+       x="-513.77948"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#808080;fill-opacity:1;stroke:none;font-family:Arial MT;-inkscape-font-specification:Arial MT"
+       xml:space="preserve"><tspan
+         style="font-size:12px;fill:#808080;fill-opacity:1"
+         y="53.149605"
          x="-513.77948"
-         y="70.866142"
-         style="font-size:12px">230mm</tspan></text>
+         id="tspan4332"
+         sodipodi:role="line">230mm</tspan></text>
     <text
-       xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Arial MT;-inkscape-font-specification:Arial MT"
-       x="354.33072"
-       y="159.44879"
+       sodipodi:linespacing="125%"
        id="text4334"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
+       y="70.866119"
+       x="460.62991"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#808080;fill-opacity:1;stroke:none;font-family:Arial MT;-inkscape-font-specification:Arial MT"
+       xml:space="preserve"><tspan
+         style="font-size:12px;fill:#808080;fill-opacity:1"
+         y="70.866119"
+         x="460.62991"
          id="tspan4336"
-         x="354.33072"
-         y="159.44879"
-         style="font-size:12px">180mm</tspan></text>
+         sodipodi:role="line">180mm</tspan></text>
     <path
-       style="fill:#000000;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
-       d="m 372.04724,70.86612 0,-17.716536 -7.08661,0 14.17323,-10.629921 14.17323,10.629921 -7.08662,0 0,17.716536 z"
+       inkscape:connector-curvature="0"
        id="path2998"
-       inkscape:connector-curvature="0" />
+       d="m 372.04724,70.86612 0,-17.716536 -7.08661,0 14.17323,-10.629921 14.17323,10.629921 -7.08662,0 0,17.716536 z"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3237"
+       d="m -17.716535,-2.2107222e-5 35.43307,0"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3239"
+       d="M 0,17.716513 0,-17.716558"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4334-5"
+       y="159.44879"
+       x="17.716536"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#808080;fill-opacity:1;stroke:none;display:inline;font-family:Arial MT;-inkscape-font-specification:Arial MT"
+       xml:space="preserve"><tspan
+         style="font-size:12px;fill:#808080;fill-opacity:1"
+         y="159.44879"
+         x="17.716536"
+         id="tspan4336-3"
+         sodipodi:role="line">15mm</tspan></text>
+    <text
+       inkscape:transform-center-y="-18.071825"
+       inkscape:transform-center-x="85.006143"
+       transform="matrix(0,-1,1,0,0,0)"
+       sodipodi:linespacing="125%"
+       id="text4330-5"
+       y="141.73228"
+       x="-70.866119"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#808080;fill-opacity:1;stroke:none;display:inline;font-family:Arial MT;-inkscape-font-specification:Arial MT"
+       xml:space="preserve"><tspan
+         id="tspan4106"
+         style="font-size:12px;fill:#808080;fill-opacity:1"
+         y="141.73228"
+         x="-70.866119"
+         sodipodi:role="line">20mm</tspan></text>
   </g>
+  <g
+     style="display:inline"
+     inkscape:label="Print"
+     id="layer3"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:inline"
+     inkscape:label="Plot"
+     id="layer2"
+     inkscape:groupmode="layer" />
 </svg>

--- a/examples/registration-marks.svg
+++ b/examples/registration-marks.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="Silhouette-Passermarken.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.7"
+     inkscape:cx="145.62755"
+     inkscape:cy="591.92317"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:snap-grids="true"
+     inkscape:snap-page="true"
+     units="mm">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4328"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       units="mm"
+       spacingx="1mm"
+       spacingy="1mm"
+       originy="297mm" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.77165353;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect2985"
+       width="17.716536"
+       height="17.716536"
+       x="54.035435"
+       y="71.751846" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:3.54330707;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 620.07874,70.866114 70.86614,0 0,70.866146"
+       id="path3755"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:3.54330707;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 125.7874,884.0551 -70.86614,0 0,-70.86614"
+       id="path3755-5"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Arial MT;-inkscape-font-specification:Arial MT"
+       x="-513.77948"
+       y="70.866142"
+       id="text4330"
+       sodipodi:linespacing="125%"
+       transform="matrix(0,-1,1,0,0,0)"
+       inkscape:transform-center-x="85.006143"
+       inkscape:transform-center-y="-18.071825"><tspan
+         sodipodi:role="line"
+         id="tspan4332"
+         x="-513.77948"
+         y="70.866142"
+         style="font-size:12px">230mm</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Arial MT;-inkscape-font-specification:Arial MT"
+       x="354.33072"
+       y="159.44879"
+       id="text4334"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4336"
+         x="354.33072"
+         y="159.44879"
+         style="font-size:12px">180mm</tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="m 372.04724,70.86612 0,-17.716536 -7.08661,0 14.17323,-10.629921 14.17323,10.629921 -7.08662,0 0,17.716536 z"
+       id="path2998"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -64,8 +64,8 @@ Pressure values of 19 or more make the machine misbehave. Beware.
       <param name="regsearch_help" type="description">Search for the registration marks automatically. Seems on some devices there is another mode, where you can set the references manually.</param>
       <param name="regwidth" type="float" min="0.0" max="10000" _gui-text="X mark distance [mm]">180</param>
       <param name="reglength" type="float" min="0.0" max="10000" _gui-text="Y mark distance [mm]">230</param>
-      <param name="regoriginx" type="float" min="0.0" max="10000" _gui-text="Position of regmark from document left [mm]">15</param>
-      <param name="regoriginy" type="float" min="0.0" max="10000" _gui-text="Position of regmark from document top [mm]">20</param>
+      <param name="regoriginx" type="float" min="10.0" max="10000" _gui-text="Position of regmark from document left [mm]">15</param>
+      <param name="regoriginy" type="float" min="10.0" max="10000" _gui-text="Position of regmark from document top [mm]">20</param>
       <param name="regdistance_help" type="description">Distance of the registration mark edges</param>
     </page>
 

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -64,8 +64,8 @@ Pressure values of 19 or more make the machine misbehave. Beware.
       <param name="regsearch_help" type="description">Search for the registration marks automatically. Seems on some devices there is another mode, where you can set the references manually.</param>
       <param name="regwidth" type="float" min="0.0" max="10000" _gui-text="X mark distance [mm]">180</param>
       <param name="reglength" type="float" min="0.0" max="10000" _gui-text="Y mark distance [mm]">230</param>
-      <param name="regoriginx" type="float" min="0.0" max="10000" _gui-text="X-offset of regmark to document origin [mm]">15</param>
-      <param name="regoriginy" type="float" min="0.0" max="10000" _gui-text="Y-offset of regmark to document origin [mm]">20</param>
+      <param name="regoriginx" type="float" min="0.0" max="10000" _gui-text="Position of regmark from document left [mm]">15</param>
+      <param name="regoriginy" type="float" min="0.0" max="10000" _gui-text="Position of regmark from document top [mm]">20</param>
       <param name="regdistance_help" type="description">Distance of the registration mark edges</param>
     </page>
 

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -59,9 +59,9 @@ Pressure values of 19 or more make the machine misbehave. Beware.
 
     <page name='reg' _gui-text='Regmarks'>
       <param name="regmark" type="boolean" _gui-text="The document has registration marks">false</param>
-      <param name="regmark_help" type="description">???</param>
-      <param name="regsearch" type="boolean" _gui-text="Search for the regitration marks">false</param>
-      <param name="regsearch_help" type="description">???</param>
+      <param name="regmark_help" type="description">The document contains printed registration marks</param>
+      <param name="regsearch" type="boolean" _gui-text="Search for the regitration marks automatically">false</param>
+      <param name="regsearch_help" type="description">Search for the registration marks automatically. Seems on some devices there is another mode, where you can set the references manually.</param>
       <param name="regwidth" type="float" min="0.0" max="10000" _gui-text="X mark distance [mm]">180</param>
       <param name="reglength" type="float" min="0.0" max="10000" _gui-text="Y mark distance [mm]">230</param>
       <param name="regdistance_help" type="description">Distance of the registration mark edges</param>

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -64,6 +64,8 @@ Pressure values of 19 or more make the machine misbehave. Beware.
       <param name="regsearch_help" type="description">Search for the registration marks automatically. Seems on some devices there is another mode, where you can set the references manually.</param>
       <param name="regwidth" type="float" min="0.0" max="10000" _gui-text="X mark distance [mm]">180</param>
       <param name="reglength" type="float" min="0.0" max="10000" _gui-text="Y mark distance [mm]">230</param>
+      <param name="regoriginx" type="float" min="0.0" max="10000" _gui-text="X-offset of regmark to document origin [mm]">15</param>
+      <param name="regoriginy" type="float" min="0.0" max="10000" _gui-text="Y-offset of regmark to document origin [mm]">20</param>
       <param name="regdistance_help" type="description">Distance of the registration mark edges</param>
     </page>
 

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -305,9 +305,13 @@ class SendtoSilhouette(inkex.Effect):
           action = 'store', dest = 'regsearch', type = 'inkbool', default = False,
           help="Search for the regitration marks.")
     self.OptionParser.add_option('-X', '--reg-x', '--regwidth', action = 'store',
-          type = 'float', dest = 'regwidth', default = 18.0, help="X mark distance [mm]")
+          type = 'float', dest = 'regwidth', default = 180.0, help="X mark distance [mm]")
     self.OptionParser.add_option('-Y', '--reg-y', '--reglength', action = 'store',
           type = 'float', dest = 'reglength', default = 230.0, help="Y mark distance [mm]")
+    self.OptionParser.add_option('--rego-x',  '--regoriginx',action = 'store',
+          type = 'float', dest = 'regoriginx', default = 15.0, help="X mark origin from left [mm]")
+    self.OptionParser.add_option('--rego-y', '--regoriginy', action = 'store',
+          type = 'float', dest = 'regoriginy', default = 20.0, help="X mark origin from top [mm]")
 
   def version(self):
     return __version__
@@ -1022,7 +1026,8 @@ class SendtoSilhouette(inkex.Effect):
         margintop=0, marginleft=0,
         bboxonly=None,         # only return the bbox, do not draw it.
         regmark=self.options.regmark,regsearch=self.options.regsearch,
-        regwidth=self.options.regwidth,reglength=self.options.reglength)
+        regwidth=self.options.regwidth,reglength=self.options.reglength,
+        regoriginx=self.options.regoriginx,regoriginy=self.options.regoriginy)
 
       if len(bbox['bbox'].keys()):
         print >>self.tty, "autocrop left=%.1fmm top=%.1fmm" % (
@@ -1037,7 +1042,8 @@ class SendtoSilhouette(inkex.Effect):
       offset=(self.options.x_off,self.options.y_off),
       bboxonly=self.options.bboxonly,
       regmark=self.options.regmark,regsearch=self.options.regsearch,
-      regwidth=self.options.regwidth,reglength=self.options.reglength)
+      regwidth=self.options.regwidth,reglength=self.options.reglength,
+      regoriginx=self.options.regoriginx,regoriginy=self.options.regoriginy)
     if len(bbox['bbox'].keys()) == 0:
       print >>self.tty, "empty page?"
       print >>sys.stderr, "empty page?"

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -1013,8 +1013,9 @@ class SendtoSilhouette(inkex.Effect):
         percent_per_sec = 1000.     # unreliable data
 
       wait_sec = 1
-      while (percent_per_sec*wait_sec < 1.6):   # max 60 dots
-        wait_sec *= 2
+      if percent_per_sec > 1: # prevent overflow if device_buffer_perc is almost 100
+        while (percent_per_sec*wait_sec < 1.6):   # max 60 dots
+          wait_sec *= 2
       dots = '.'
       while self.options.wait_done and state == 'moving':
         time.sleep(wait_sec)

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -752,6 +752,10 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       print("bb regoriginx=%g regoriginy=%g" % (regoriginx, regoriginy), file=s.log)
       offset = (offset[0] - regoriginx, offset[1] - regoriginy)
       
+      # Limit the cutting area inside cutting marks
+      height = reglength * 20.0
+      width = regwidth * 20.0
+
       s.write("TB50,0\x03") #only with registration (it was TB50,1), landscape mode
       s.write("TB99\x03")
       s.write("TB52,2\x03")     #type of regmarks: 0='Original,SD', 2='Cameo,Portrait'
@@ -761,7 +765,8 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       
       if regsearch:
         # automatic regmark test, height, width, top, left
-        s.write("TB123,%i,%i,118,18\x03" % (reglength * 20.0, regwidth * 20.0))
+        # add a search range of 10mm
+        s.write("TB123,%i,%i,%i,%i\x03" % (reglength * 20.0, regwidth * 20.0, (regoriginy - 10)  * 20.0, (regoriginx - 10) * 20.0))
       else:
       	# manual regmark, height, width
         s.write("TB23,%i,%i\x03" % (reglength * 20.0, regwidth * 20.0))

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -405,11 +405,27 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       pass
     
     # Additional commands seen in init by Silhouette Studio
+    #s.write("[\x03") # asks for something, no idea, just repeating sniffed communication
+    #try:
+    #  resp = s.read(timeout=1000)
+    #  if len(resp) > 1:
+    #  print("[: '%s'" % (resp[:-1]), file=s.log)	# response '0,0'
+    #except:
+    #  pass
+
+    #s.write("U\x03") # asks for something, no idea, just repeating sniffed communication
+    #try:
+    #  resp = s.read(timeout=1000)
+    #  if len(resp) > 1:
+    #  print("U: '%s'" % (resp[:-1]), file=s.log)	# response '20320,4120' max. print range?
+    #except:
+    #  pass
+
     #s.write("FQ0\x03") # asks for something, no idea, just repeating sniffed communication
     #try:
     #  resp = s.read(timeout=1000)
     #  if len(resp) > 1:
-    #  print("FQ0: '%s'" % (resp[:-1]), file=s.log)
+    #  print("FQ0: '%s'" % (resp[:-1]), file=s.log)	# response '10'
     #except:
     #  pass
     
@@ -417,7 +433,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     #try:
     #  resp = s.read(timeout=1000)
     #  if len(resp) > 1:
-    #  print("FQ2: '%s'" % (resp[:-1]), file=s.log)
+    #  print("FQ2: '%s'" % (resp[:-1]), file=s.log)	# response '18'
     #except:
     #  pass
     
@@ -433,7 +449,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     #try:
     #  resp = s.read(timeout=1000)
     #  if len(resp) > 1:
-    #  print("FA: '%s'" % (resp[:-1]), file=s.log)
+    #  print("FA: '%s'" % (resp[:-1]), file=s.log) # response '0,0'
     #except:
     #  pass
 
@@ -530,7 +546,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     s.write("FE0,0\x03")
 
   def find_bbox(s, cut):
-    """Find the bouding box of the cut, returns (xmin,ymin,xmax,ymax)"""
+    """Find the bounding box of the cut, returns (xmin,ymin,xmax,ymax)"""
     bb = {}
     for path in cut:
       for pt in path:
@@ -727,7 +743,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
         offset = (offset, 0)
 
     if regmark:
-      s.write("TB50,0\x03") #only with registration (it was TB50,1) ???
+      s.write("TB50,0\x03") #only with registration (it was TB50,1), landscape mode
       s.write("TB99\x03")
       s.write("TB52,2\x03")     #type of regmarks: 0='Original,SD', 2='Cameo,Portrait'
       s.write("TB51,400\x03")   # length of regmarks
@@ -780,7 +796,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     p = '\x03'.join(cmd_list)
 
     if bboxonly == True:
-      # move the bouding box
+      # move the bounding box
       p = "M%d,%d" % (int(0.5+bbox['ury']), int(0.5+bbox['llx']))
       p += "\x03D%d,%d" % (int(0.5+bbox['ury']), int(0.5+bbox['urx']))
       p += "\x03D%d,%d" % (int(0.5+bbox['lly']), int(0.5+bbox['urx']))

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -689,35 +689,40 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
         offset = (offset, 0)
 
     s.write("FU%d,%d\x03" % (height-top, width-left))
-    s.write("FN0\x03")          # // ?
+    s.write("FN0\x03")          # Orientation of coordinate system
     if regmark:
       s.write("TB50,0\x03") #only with registration (it was TB50,1) ???
       s.write("TB99\x03")
-      s.write("TB52,2\x03")
-      s.write("TB51,400\x03")
-      s.write("TB53,10\x03")
+      s.write("TB52,2\x03")     #type of regmarks: 0='Original,SD', 2='Cameo,Portrait'
+      s.write("TB51,400\x03")   # length of regmarks
+      s.write("TB53,10\x03")    # width of regmarks
       s.write("TB55,1\x03")
       
       if regsearch:
-        cmd="123"
+        # automatic regmark test, height, width, top, left
+        s.write("TB123,%i,%i,118,18\x03" % (reglength * 20.0, regwidth * 20.0))
       else:
-        cmd="23"
-      ## registration mark test /1-2: 180.0mm / 1-3: 230.0mm (origin 15mmx20mm)
-      s.write("TB%s,%i,%i,118,18\x03" % (cmd, regwidth * 20.0, reglength * 20.0))
+      	# manual regmark, height, width
+        s.write("TB23,%i,%i\x03" % (reglength * 20.0, regwidth * 20.0))
       
-      s.write("FQ5\x03") ## only with registration ???
+      #while True:
+      #  s.write("\1b\05") #request status
+      #  resp = s.read(timeout=1000)
+      #  if resp != "    1\x03":
+      #  	break;
+        	
       resp = s.read(timeout=40000) ## Allow 20s for reply...
       if resp != "    0\x03":
         raise ValueError("Couldn't find registration marks. %s" % str(resp))
       
       ## Looks like if the reg marks work it gets 3 messages back (if it fails it times out because it only gets the first message)
-      resp = s.read(timeout=40000) ## Allow 20s for reply...
-      if resp != "    0\x03":
-        raise ValueError("Couldn't find registration marks.")
+      #resp = s.read(timeout=40000) ## Allow 20s for reply...
+      #if resp != "    0\x03":
+        #raise ValueError("Couldn't find registration marks. (2)(%s)" % str(resp))
       
       #resp = s.read(timeout=40000) ## Allow 20s for reply...
       #if resp != "    1\x03":
-        #raise ValueError("Couldn't find registration marks.")
+        #raise ValueError("Couldn't find registration marks. (3)")
     else:
       s.write("TB50,1\x03")     # ???
 
@@ -725,6 +730,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     s.write("FO%d\x03" % (height-top))
 
     p = "&100,100,100,\\0,0,Z%d,%d,L0" % (width,height)		# scale
+    #p = "\\0,0\x03Z%d,%d\x03" % (width,height)		# scale
 
     bbox['clip'] = {'urx':width, 'ury':top, 'llx':left, 'lly':height}
     bbox['only'] = bboxonly

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -688,7 +688,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
   def plot(s, mediawidth=210.0, mediaheight=297.0, margintop=None,
            marginleft=None, pathlist=None, offset=None, bboxonly=False,
            end_paper_offset=0, regmark=False, regsearch=False,
-           regwidth=180, reglength=230):
+           regwidth=180, reglength=230, regoriginx=15.0, regoriginy=20.0):
     """plot sends the pathlist to the device (real or dummy) and computes the
        bounding box of the pathlist, which is returned.
 
@@ -743,6 +743,15 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
         offset = (offset, 0)
 
     if regmark:
+      # after registration logically (0,0) is at regmark position
+      # compensate the offset of the regmark to the svg document origin. 
+      #bb = s.find_bbox(pathlist)
+      #print("bb llx=%g ury=%g" % (bb['llx'], bb['ury']), file=s.log)
+      #regoriginx = bb['llx']
+      #regoriginy = bb['ury']
+      print("bb regoriginx=%g regoriginy=%g" % (regoriginx, regoriginy), file=s.log)
+      offset = (offset[0] - regoriginx, offset[1] - regoriginy)
+      
       s.write("TB50,0\x03") #only with registration (it was TB50,1), landscape mode
       s.write("TB99\x03")
       s.write("TB52,2\x03")     #type of regmarks: 0='Original,SD', 2='Cameo,Portrait'

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -272,9 +272,9 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       chunk = string[o:o+chunksz]
       try:
         if s.need_interface:
-          r = s.dev.write(endpoint, string[o:o+chunksz], interface=0, timeout=timeout)
+          r = s.dev.write(endpoint, chunk, interface=0, timeout=timeout)
         else:
-          r = s.dev.write(endpoint, string[o:o+chunksz], timeout=timeout)
+          r = s.dev.write(endpoint, chunk, timeout=timeout)
       except TypeError as te:
         # write() got an unexpected keyword argument 'interface'
         raise TypeError("Write Exception: %s, %s dev=%s" % (type(te), te, type(s.dev)))
@@ -376,10 +376,52 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     # taken from robocut/Plotter.cpp:331 ff
     # Initialise plotter.
     s.write("\x1b\x04")
+    
+    # Initial palaver
+    try:
+      s.write("FG\x03")   # query device name
+    except Exception as e:
+      raise ValueError("Write Exception: %s, %s errno=%s\n\nFailed to write the first 3 bytes. Permissions? inf-wizard?" % (type(e), e, e.errno))
 
-  def home(s):
-    """Send the home command. Untested. Called by setup()."""
-    s.write("TT\x03")
+    try:
+      resp = s.read(timeout=1000)
+      if len(resp) > 1:
+        print("FG: '%s'" % (resp[:-1]), file=s.log)
+    except:
+      pass
+    
+    # Additional commands seen in init by Silhouette Studio
+    #s.write("FQ0\x03") # asks for something, no idea, just repeating sniffed communication
+    #try:
+    #  resp = s.read(timeout=1000)
+    #  if len(resp) > 1:
+    #  print("FQ0: '%s'" % (resp[:-1]), file=s.log)
+    #except:
+    #  pass
+    
+    #s.write("FQ2\x03") # asks for something, no idea, just repeating sniffed communication
+    #try:
+    #  resp = s.read(timeout=1000)
+    #  if len(resp) > 1:
+    #  print("FQ2: '%s'" % (resp[:-1]), file=s.log)
+    #except:
+    #  pass
+    
+    #s.write("TB71\x03") # asks for something, no idea, just repeating sniffed communication
+    #try:
+    #  resp = s.read(timeout=1000)
+    #  if len(resp) > 1:
+    #  print("TB71: '%s'" % (resp[:-1]), file=s.log)
+    #except:
+    #  pass
+    
+    #s.write("FA\x03") # asks for something, not sure, current position?
+    #try:
+    #  resp = s.read(timeout=1000)
+    #  if len(resp) > 1:
+    #  print("FA: '%s'" % (resp[:-1]), file=s.log)
+    #except:
+    #  pass
 
   def get_version(s):
     """Retrieve the firmware version string from the device."""
@@ -395,7 +437,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     return resp[0:-2]   # chop of 0x03
 
 
-  def setup(s, media=132, speed=None, pressure=None, pen=None, trackenhancing=False, landscape=False, leftaligned=None, return_home=True):
+  def setup(s, media=132, speed=None, pressure=None, pen=None, trackenhancing=False, landscape=False, leftaligned=None):
     """media range is [100..300], default 132, "Print Paper Light Weight"
        speed range is [1..10], default None, from paper (132 -> 10)
        pressure range is [1..33], default None, from paper (132 -> 5)
@@ -410,12 +452,9 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     if leftaligned is not None:
       s.leftaligned = leftaligned
 
-    s.return_home = return_home
-
     if s.dev is None: return None
 
     s.initialize()
-    s.home()
 
     if media is not None:
       if media < 100 or media > 300: media = 300
@@ -464,20 +503,17 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       else:
         s.write("FY0\x03")
 
+    #FNx, x = 0 seem to be some kind of reset, x = 1: plotter head moves to other
+    # side of media (boundary check?), but next cut run will stall
+    #TB50,x: x = 1 landscape mode, x = 0 portrait mode
     if landscape is not None:
       if landscape:
-        s.write("FN1\x03")
+        s.write("FN0\x03TB50,1\x03")
       else:
-        s.write("FN0\x03")
-
-    # // No idea what this does.
-    s.write("FE0\x03")
-
-    # // Again, no idea. Maybe something to do with registration marks?
-    s.write("TB71\x03")
-    resp = s.read(timeout=10000)        # // Allow 10s. Seems reasonable.
-    if resp != "    0,    0\x03":
-      raise ValueError("setup: Invalid response from plotter.")
+        s.write("FN0\x03TB50,0\x03")
+    
+    # Don't lift plotter head between paths
+    s.write("FE0,0\x03")
 
   def find_bbox(s, cut):
     """Find the bouding box of the cut, returns (xmin,ymin,xmax,ymax)"""
@@ -518,7 +554,25 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
         otherwise a hardcoded flipwidth is used to make the coordinate system left aligned.
         x_off_mm, y_off_mm are in mm, relative to the clip urx, ury.
     """
-    flipwidth = int(12*25.4*20)		# 6096? physical device width of the Silhouette Cameo
+
+    # Change by Alexander Senger:
+    # Well, there seems to be a clash of different coordinate systems here:
+    # Cameo uses a system with the origin in the top-left corner, x-axis 
+    # running from top to bottom and y-axis from left to right.
+    # Inkscape uses a system where the origin is also in the top-left corner
+    # but x-axis is running from left to right and y-axis from top to 
+    # bottom.
+    # The transform between these two systems used so far was to set Cameo in
+    # landscape-mode ("FN0.TB50,1" in Cameo-speak) and flip the x-coordinates
+    # around the mean x-value (rotate by 90 degrees, mirror and shift x).
+    # My proposed change: just swap x and y in the data (mirror about main diagonal)
+    # This is easier and avoids utilizing landscape-mode.
+    # Why should we bother? Pure technical reason: At the beginning of each cutting run,
+    # Cameo makes a small "tick" in the margin of the media to align the blade.
+    # This gives a small offset which is automatically compensated for in 
+    # portrait mode but not (correctly) in landscape mode.
+    # As a result we get varying offsets which can be really annoying if doing precision
+    # work.
 
     x_off = x_off_mm * 20.
     y_off = y_off_mm * 20.
@@ -563,7 +617,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
             bbox['clip']['count'] = 1
 
       if bbox['only'] is False:
-        plotcmds.append("M%d,%d" % (int(0.5+flipwidth-x), int(0.5+y)))
+        plotcmds.append("M%d,%d" % (int(0.5+y), int(0.5+x)))
 
       for j in range(1,len(path)):
         x = path[j][0]*20. + x_off
@@ -593,15 +647,15 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
 
         if bbox['only'] is False:
           if inside and last_inside:
-            plotcmds.append("D%d,%d" % (int(0.5+flipwidth-x), int(0.5+y)))
+            plotcmds.append("D%d,%d" % (int(0.5+y), int(0.5+x)))
           else:
             # // if outside the range just move
-            plotcmds.append("M%d,%d" % (int(0.5+flipwidth-x), int(0.5+y)))
+            plotcmds.append("M%d,%d" % (int(0.5+y), int(0.5+x)))
         last_inside = inside
     return plotcmds
 
 
-  def plot(s, mediawidth=210.0, mediaheight=297.0, margintop=None, marginleft=None, pathlist=None, offset=None, bboxonly=False, end_paper_offset=0, no_trailer=False):
+  def plot(s, mediawidth=210.0, mediaheight=297.0, margintop=None, marginleft=None, pathlist=None, offset=None, bboxonly=False, end_paper_offset=0):
     """plot sends the pathlist to the device (real or dummy) and computes the
        bounding box of the pathlist, which is returned.
 
@@ -620,9 +674,6 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
                 If the end_paper_offset is negative, the end position is within the drawing
                 (reverse movmeents are clipped at the home position)
                 It reverse over the last home position.
-       no_trailer: Default false: The plot is properly terminated.
-                If true: The device is left hanging at the last position. You are expected to
-                extract the trailer from the return value, and send it ising the write() method later.
        Example: The letter Y (20mm tall, 9mm wide) can be generated with
                 pathlist=[[(0,0),(4.5,10),(4.5,20)],[(9,0),(4.5,10)]]
     """
@@ -643,19 +694,6 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
 
     print("mediabox: (%g,%g)-(%g,%g)" % (marginleft,margintop, mediawidth,mediaheight), file=s.log)
 
-    # // Begin page definition.
-    try:
-      s.write("FA\x03")   # query someting?
-    except Exception as e:
-      raise ValueError("Write Exception: %s, %s errno=%s\n\nFailed to write the first 3 bytes. Permissions? inf-wizard?" % (type(e), e, e.errno))
-
-    try:
-      resp = s.read(timeout=10000)
-      if len(resp) > 1:
-        print("FA: '%s'" % (resp[:-1]), file=s.log)
-    except:
-      pass
-
     width  = int(0.5+20.*mediawidth)
     height = int(0.5+20.*mediaheight)
     top    = int(0.5+20.*margintop)
@@ -671,49 +709,45 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       if type(offset) != type([]) and type(offset) != type(()):
         offset = (offset, 0)
 
-    s.write("FU%d,%d\x03" % (height-top, width-left))
-    s.write("FM1\x03")          # // ?
     if s.regmark:
       raise ValueError("regmark code not impl. see robocut/Plotter.cpp:446")
-    else:
-      s.write("TB50,1\x03")     #; // ???
 
-    # // I think this is the feed command. Sometimes it is 5588 - maybe a maximum?
-    s.write("FO%d\x03" % (height-top))
-
-    p = "&100,100,100,\\0,0,Z%d,%d,L0" % (width,height)		# scale
+    #FMx, x = 0/1: 1 leads to additional horizontal offset of 5 mm, why? Has other profound
+    # impact (will not cut in certain configuration if x=0). Seems dangerous. Not used
+    # in communtication of Sil Studio with Cameo2.
+    #FEx,0 , x = 0 cutting of distinct paths in one go, x = 1 head is lifted at sharp angles
+    #\xmin, ymin Zxmax,ymax, designate cutting area
+    
+    p = "\\0,0\x03Z%d,%d\x03L0\x03FE0,0\x03FF0,0,0\x03" % (height, width) #FIXME Is coordinate swap necessary here?
+    s.write(p)
 
     bbox['clip'] = {'urx':width, 'ury':top, 'llx':left, 'lly':height}
     bbox['only'] = bboxonly
     cmd_list = s.plot_cmds(pathlist,bbox,offset[0],offset[1])
-    p += ',' + ','.join(cmd_list)
+    p = '\x03'.join(cmd_list)
 
     if bboxonly == True:
       # move the bouding box
-      p += ",M%d,%d" % (int(0.5+width-bbox['llx']), int(0.5+bbox['ury']))
-      p += ",D%d,%d" % (int(0.5+width-bbox['urx']), int(0.5+bbox['ury']))
-      p += ",D%d,%d" % (int(0.5+width-bbox['urx']), int(0.5+bbox['lly']))
-      p += ",D%d,%d" % (int(0.5+width-bbox['llx']), int(0.5+bbox['lly']))
-      p += ",D%d,%d" % (int(0.5+width-bbox['llx']), int(0.5+bbox['ury']))
+      p = "M%d,%d" % (int(0.5+bbox['ury']), int(0.5+bbox['llx']))
+      p += "\x03D%d,%d" % (int(0.5+bbox['ury']), int(0.5+bbox['urx']))
+      p += "\x03D%d,%d" % (int(0.5+bbox['lly']), int(0.5+bbox['urx']))
+      p += "\x03D%d,%d" % (int(0.5+bbox['lly']), int(0.5+bbox['llx']))
+      p += "\x03D%d,%d" % (int(0.5+bbox['ury']), int(0.5+bbox['llx']))
+    p += "\x03"   # Properly terminate string of plot commands.
 
     trailer = []
-    trailer.append("&1,1,1,TB50,0\x03")   #; // TB maybe .. ah I dunno. Need to experiment. No idea what &1,1,1 does either.
-    trailer.append("FO0\x03")             # // Feed the page out.
-    trailer.append("H,")                  # // Halt? Really move home!
-
+    
+    # Silhouette Cameo2 does not start new job if not properly parked on left side
+    # Attention: This needs the media to not extend beyond the left stop
     if not 'llx' in bbox: bbox['llx'] = 0	# survive empty pathlist
     if not 'lly' in bbox: bbox['lly'] = 0
     if not 'urx' in bbox: bbox['urx'] = 0
     if not 'ury' in bbox: bbox['ury'] = 0
-    new_home = ",M%d,%dSO0FN0" % (int(0.5+width-bbox['llx']), int(0.5+bbox['lly']+end_paper_offset*20.))
+    new_home = "M%d,%d\x03SO0\x03" % (int(0.5+bbox['lly']+end_paper_offset*20.), 0)
 
-    if no_trailer:
-      s.write(p)
-      if not s.return_home: trailer.insert(0, new_home)
-    else:
-      if not s.return_home: p += new_home
-      s.write(p)
-      s.write(''.join(trailer))
+    
+    s.write(p)
+    s.write(new_home)
 
     return {
         'bbox': bbox,
@@ -723,7 +757,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
 
 
   def move_origin(s, feed_mm):
-    new_home = "M%d,%dSO0FN0" % (int(0.5+feed_mm*20.),0)
+    new_home = "M%d,%d\x03SO0\x03FN0" % (int(0.5+feed_mm*20.),0)
     s.wait_for_ready(verbose=False)
     s.write(new_home)
     s.wait_for_ready(verbose=False)


### PR DESCRIPTION
I have created a branch registrationmarks, in which I got the regmark functionality to work. 

My silhouette portrait has succesfully searched and found the registration marks. It's tested with Ubuntu 14.04. No idea if this works on a cameo too. Needs testing.

To get it working, I had to pull in some changes from Alexander Senger, which sets the default coordinate system from landscape to portrait mode. 

To plot with registration marks do the following:
1. Open the document examples/registration-marks.svg
2. Insert your cutting paths and graphics.
3. Printout the whole document including registration marks.
4. Select your cutting paths in the document, but exclude regmarks and graphics.
5. Set or ensure the correct values (offset/width/height) on the regmark tab.
6. Enable 'Document has registration marks' and 'Search for registration marks'
7. Start cut.

The plotter will search the registration marks at the given positions. If it founds the marks, they will serve as accurate reference and define the origin. Therefore it is necessary to set the correct offset values of the mark. As a result the cut will go precisely along the graphics.

A further improvement (not yet implemented) would be automatic detection of the regmarks in the svg by ID, so it would not be necessary to set the numbers by hand. 
