### PR TITLE
Create overcuts on closed paths

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -54,6 +54,7 @@ Pressure values of 19 or more make the machine misbehave. Beware.
       <param name="autocrop" type="boolean" _gui-text="Trim margins">false</param> <param name="autocrop_help" type="description">Shift to the top lefthand corner, then do offsets.</param>
       <param name="bbox_only" type="boolean" _gui-text="Draft Bounding Box Only">false</param>
       <param name="bbox_help" type="description">To see the used area, tick the checkmark above and use pressure=1 (or better remove tool)</param>
+      <param name="overcut" type="float" min="0.0" max="5.0" _gui-text="Overcut on closed paths [mm]">0.5</param>
       <param name="multipass" type="int" min="1" max="8" _gui-text="Repeat each stroke">1</param>
       <param name="reversetoggle" type="boolean" _gui-text="Cut in opposite direction(s)">false</param>
       <param name="endposition" type="enum" _gui-text="Position After Cutting:">

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -1015,6 +1015,23 @@ class SendtoSilhouette(inkex.Effect):
         else: 
           cut.append(mm_path)
 
+      # on a closed path some overlapping doesn't harm, limited to a maximum of one additional round
+      overcut = 0.5
+      if (overcut > 0) and (mm_path[0] == mm_path[-1]):
+        pfrom = mm_path[0]
+        for pnext in mm_path[1:]:
+          dx = pnext[0] - pfrom[0]
+          dy = pnext[1] - pfrom[1]
+          dist = math.sqrt(dx*dx + dy*dy)
+          if (overcut > dist): # Full segment needed
+            overcut -= dist
+            multipath.append(pnext)
+            pfrom = pnext
+          else:                # only partial segement needed, create new endpoint
+            pnext = (pfrom[0]+dx*(overcut/dist), pfrom[1]+dy*(overcut/dist))
+            multipath.append(pnext)
+            break
+
       cut.append(multipath)
 
     if dev.dev is None:

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -1000,10 +1000,22 @@ class SendtoSilhouette(inkex.Effect):
         else:
           mm_path.append((px2mm(pt[0]), px2mm(pt[1])))
         pointcount += 1
-      for i in range(0,self.options.multipass):
+
+      multipath = []
+      multipath.extend(mm_path)
+      for i in range(1,self.options.multipass):
+        # if reverse continue path without lifting, instead turn with rotating knife
         if (self.options.reversetoggle):
           mm_path = list(reversed(mm_path))
-        cut.append(mm_path)
+          multipath.extend(mm_path[1:])
+        # if closed path (end = start) continue path without lifting
+        elif (mm_path[0] == mm_path[-1]):
+          multipath.extend(mm_path[1:])
+        # else start a new path
+        else: 
+          cut.append(mm_path)
+
+      cut.append(multipath)
 
     if dev.dev is None:
       docname=None

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -278,6 +278,9 @@ class SendtoSilhouette(inkex.Effect):
              '120','121','122','123','124','125','126','127','128','129','130',
              '131','132','133','134','135','136','137','138','300'),
           help="113 = pen, 132 = printer paper, 300 = custom")
+    self.OptionParser.add_option('-o', '--overcut',
+          action = 'store', dest = 'overcut', type = 'float', default = 0.5,
+          help="overcut on circular paths. [mm]")
     self.OptionParser.add_option('-M', '--multipass',
           action = 'store', dest = 'multipass', type = 'int', default = '1',
           help="[1..8], cut/draw each path object multiple times.")
@@ -1016,7 +1019,7 @@ class SendtoSilhouette(inkex.Effect):
           cut.append(mm_path)
 
       # on a closed path some overlapping doesn't harm, limited to a maximum of one additional round
-      overcut = 0.5
+      overcut = self.options.overcut
       if (overcut > 0) and (mm_path[0] == mm_path[-1]):
         pfrom = mm_path[0]
         for pnext in mm_path[1:]:


### PR DESCRIPTION
I am using this patch since some time. I have now found the time to cleanup and rebase the code.

The changes are:
- On closed paths with multiple passes the knive is not lifted, but the cut continued in one stroke. THis is also the case when using reverse cuts. This makes cleaner cuts and less noise :-)
- On closed paths there is added some additional overcut by repeating the begin of the given path. For some difficulty materials it is needed to finish the cut completely and cut free the cutout.
- This overcut is active only on closed paths.
- The length of the overcut is parametisable.