### PR TITLE
Adding support for cameo 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ VERS=$$(echo '<xml height="0"/>' | python ./sendto_silhouette.py --version /dev/
 DEST=$(DESTDIR)$(PREFIX)/share/inkscape/extensions
 UDEV=$(DESTDIR)/lib/udev
 
+# User-specifc inkscape extensions folder for local install
+DESTLOCAL=$(HOME)/.config/inkscape/extensions
+
 dist:
 	cd distribute; sh ./distribute.sh
 
@@ -38,6 +41,12 @@ install:
 	install -m 644 -t $(UDEV) silhouette-icon.png
 	install -m 644 -t $(UDEV) silhouette-udev-notify.sh
 
+install-local:
+	mkdir -p $(DESTLOCAL)
+	# CAUTION: cp -a does not work under fakeroot. Use cp -r instead.
+	cp -r silhouette $(DESTLOCAL)
+	install -m 755 -t $(DESTLOCAL) *.py
+	install -m 644 -t $(DESTLOCAL) *.inx
 
 tar_dist_classic: clean
 	name=$(DISTNAME)-$(VERS); echo "$$name"; echo; \

--- a/silhouette-udev.rules
+++ b/silhouette-udev.rules
@@ -1,7 +1,8 @@
 OPTIONS:="lastrule"
 OPTIONS:="last_rule"
 
-ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1121", MODE="666", ENV{silhouette_cameo}="yes", OPTIONS="last_rule"
+ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="112f", MODE="666", ENV{silhouette_cameo3}="yes", OPTIONS="last_rule"
+ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1121", MODE="666", ENV{silhouette_cameo}="yes"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1123", MODE="666", ENV{silhouette_portrait}="yes"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="111d", MODE="666", ENV{silhouette_sd_2}="yes"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="111c", MODE="666", ENV{silhouette_sd_1}="yes"

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -129,7 +129,7 @@ DEVICE = [
  { 'vendor_id': 0x0b4d, 'product_id': 0x112f, 'name': 'Silhouette Cameo3',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!
-   'width_mm':  304, 'length_mm': 3000, 'margin_left_mm':9.0, 'margin_top_mm':1.0, 'regmark': True },
+   'width_mm':  304, 'length_mm': 3000, 'margin_left_mm':5, 'margin_top_mm':15.5, 'regmark': True },
  { 'vendor_id': 0x0b4d, 'product_id': 0x110a, 'name': 'Craft Robo CC200-20',
    'width_mm':  200, 'length_mm': 1000, 'regmark': True },
  { 'vendor_id': 0x0b4d, 'product_id': 0x111a, 'name': 'Craft Robo CC300-20' },

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -17,6 +17,7 @@
 # 2015-06-06  refactored plot_cmds() from plot().
 # 2016-05-16  no reset per default, this helps usbip.
 # 2016-05-21  detect python-usb < 1.0 and give instructions.
+# 2017-04-20  Adding Cameo3 USB IDs
 #
 
 from __future__ import print_function
@@ -122,6 +123,10 @@ DEVICE = [
    # margin_left_mm is a physical limit, but is relative to width_mm!
    'width_mm':  304, 'length_mm': 3000, 'margin_left_mm':9.0, 'margin_top_mm':1.0, 'regmark': True },
  { 'vendor_id': 0x0b4d, 'product_id': 0x112b, 'name': 'Silhouette Cameo2',
+   # margin_top_mm is just for safety when moving backwards with thin media
+   # margin_left_mm is a physical limit, but is relative to width_mm!
+   'width_mm':  304, 'length_mm': 3000, 'margin_left_mm':9.0, 'margin_top_mm':1.0, 'regmark': True },
+ { 'vendor_id': 0x0b4d, 'product_id': 0x112f, 'name': 'Silhouette Cameo3',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!
    'width_mm':  304, 'length_mm': 3000, 'margin_left_mm':9.0, 'margin_top_mm':1.0, 'regmark': True },


### PR DESCRIPTION
Added USB PID/VIDs and margins for cameo 3 machine, tested and working.
This is just basic support, things like automatic autoblade adjustment and the second toolholder are still in the works.

Also added a new makefile target (install-local) that puts the scripts in the inkscape extensions folder in your home directory if you only want to install for current user (I find this easier for development).