### PR TITLE
Update Graphtec.py for use with windows. 

### DIFF
--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -53,7 +53,11 @@ try:
       usb_vi_str = str(usb.version_info)
     except AttributeError:
       usb_vi = 0
+      if sys_platform.startswith('win'):
+        usb_vi = 1
+        pass # windows does not seem to detect the usb.version , gives attribute error. Other tests of pyusb work, pyusb is installed.
       usb_vi_str = 'unknown'
+
 
     if usb_vi < 1:
       print("Your python usb module appears to be "+usb_vi_str+" -- We need version 1.x", file=sys.stderr)


### PR DESCRIPTION
Added a test for Windows, as Windows does not seem to detect the usb.version , gives attribute error. 
If it passes the test, the plotter works fine. Other tests of pyusb work, pyusb is installed.
I am a beginner programmer, so there may be a better way of doing this.  
