### PR TITLE
Inkscape Template for US Letter in Landscape

### DIFF
--- a/examples/default_us_letter_landscape_cameo_3.svg
+++ b/examples/default_us_letter_landscape_cameo_3.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="299mm"
+   height="236mm"
+   viewBox="0 0 299.00002 236.00002"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="default.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <title
+     id="title817">US Letter Landscape For Silhouette Cameo 3 and InkScape Silhouette Extension</title>
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.7400071"
+     inkscape:cx="1070.2857"
+     inkscape:cy="873.43457"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="mm"
+     inkscape:window-width="1600"
+     inkscape:window-height="824"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815" />
+    <sodipodi:guide
+       position="59.000005,25.000002"
+       orientation="0,1130.0787"
+       id="guide830"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="274.00002,7.0000005"
+       orientation="-891.9685,0"
+       id="guide832"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15.000001,231.00002"
+       orientation="0,-1130.0787"
+       id="guide834"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.0000004,225.00002"
+       orientation="891.9685,0"
+       id="guide836"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>US Letter Landscape For Silhouette Cameo 3 and InkScape Silhouette Extension</dc:title>
+        <dc:description>This default document is designed for use with the InkScape Silhouette extension.  The guides define the useable space, allowing a 5mm edge around a standard US letter size piece of paper, in landscape mode.
+
+The page size, as far as InkScape is concerned, is approximately 20mm larger in both directions.  This allows for an issue with the silhouette extension where the bottom edge can be cut off.
+
+In short, keep your cuts inside the lines, and you won't get hurt.  Stray outside, and your cuts are likely to get lost.</dc:description>
+        <dc:date>2018-05-15</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Kedneck</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>http://creativecommons.org/licenses/by/4.0/</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:language>English</dc:language>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Template</rdf:li>
+            <rdf:li>Silhouette</rdf:li>
+            <rdf:li>Cameo</rdf:li>
+            <rdf:li>Inkscape</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-60.99997)" />
+</svg>


### PR DESCRIPTION
# DESCRIPTION

This file is a modified copy of the 'default.svg' file.  It is
configured for US Letter paper in landscape mode, for the Silhouette
Cameo 3 with cutting mat, by the following additions:

1) The overall page size has been increased by ~20mm in both directions.

   This avoids issues where the software truncates any line/cut that
   extends beyond a certain point.

2) Guides have been added which mark the 'safe' boundaries for cutting.

   The guides have been moved in from the upper left by 5mm, allowing
   a safety zone against misalignment of paper on the cutting mat.
   The lower right guides have been moved in from the edges by 25mm,
   allowing for the 20mm increase, and an additional 5mm for the
   safety zone.

3) A grid has been pre-defined, in milimeters, major lines every 10mm.

4) Both display and document units are set to milimeters.

# LICENSE

This file is under the CC BY 4.0 license as defined by:

  https://creativecommons.org/licenses/by/4.0/