### PR TITLE
Move some options to new page to reduce dialog size

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -47,6 +47,8 @@
       </param>
       <param name="speed" type="int" min="0" max="10" _gui-text="Speed">0</param>
       <param name="pressure" type="int" min="0" max="33" _gui-text="Pressure">0</param>
+    </page>
+    <page name='opt' _gui-text='Options'>
       <param name="speed_help" type="description">Use speed=0, pressure=0 to take the media defaults. Pressure values of 19 or more could trigger the trackenhancing feature, which means a movement along the full media height before start. Beware.</param>
       <param name="dashes" type="boolean" _gui-text="Convert to dashes">false</param> <param name="dashes_help" type="description">Convert paths with dashed strokes to separate subpaths for perforated cuts.</param>
       <param name="autocrop" type="boolean" _gui-text="Trim margins">false</param> <param name="autocrop_help" type="description">Shift to the top lefthand corner, then do offsets.</param>


### PR DESCRIPTION
On older notebooks or ones with smaller screen size the first page extends off bottom of screen. This small change moves a few options to a second options page reducing the dialog size so it works across more varying screen sizes.