### PR TITLE
Add file output option for remote cutting

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -87,7 +87,7 @@
       <param name="mat_free_help" type="description">Without mat: Subdivide, sort, and choose cut directions, so that a cutting mat is not needed in most cases.</param>
       <param name="mintravel_help" type="description">Minimal Traveling: Find the nearest startpoint to minimize travel movements</param>
       <param name="mintravelfull_help" type="description">Minimal Traveling (fully optimized): Additionally search startpoints in closed paths</param>
-      <param name="prnfile"    type="string" _gui-text="Output to file:">false</param>
+      <param name="prnfile"    type="string" _gui-text="Output to file:"></param>
       <param name="prnfile_help" type="description">Output cut data to file for remote cutting (across network).</param>
       <param name="dummy"    type="boolean" _gui-text="Dummy device: Send to /tmp/silhouette.dump">false</param>
       <param name="dummy_help" type="description">Used for debugging and developent only!</param>

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -87,6 +87,8 @@
       <param name="mat_free_help" type="description">Without mat: Subdivide, sort, and choose cut directions, so that a cutting mat is not needed in most cases.</param>
       <param name="mintravel_help" type="description">Minimal Traveling: Find the nearest startpoint to minimize travel movements</param>
       <param name="mintravelfull_help" type="description">Minimal Traveling (fully optimized): Additionally search startpoints in closed paths</param>
+      <param name="prnfile"    type="string" _gui-text="Output to file:">false</param>
+      <param name="prnfile_help" type="description">Output cut data to file for remote cutting (across network).</param>
       <param name="dummy"    type="boolean" _gui-text="Dummy device: Send to /tmp/silhouette.dump">false</param>
       <param name="dummy_help" type="description">Used for debugging and developent only!</param>
     </page>

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -334,6 +334,9 @@ class SendtoSilhouette(inkex.Effect):
     self.OptionParser.add_option('-e', '--endposition', '--end-postition',
           '--end_position', action = 'store', choices=('start','below'),
           dest = 'endposition', default = 'below', help="Position of head after cutting: start or below")
+    self.OptionParser.add_option('--prnfile',
+          action = 'store', dest = 'prnfile', type = 'string', default = None,
+          help="Output cut data to file for remote cutting.")
 
   def version(self):
     return __version__
@@ -976,7 +979,7 @@ class SendtoSilhouette(inkex.Effect):
       self.tty.flush()
 
     try:
-      dev = SilhouetteCameo(log=self.tty, progress_cb=write_progress, no_device=self.options.dummy)
+      dev = SilhouetteCameo(log=self.tty, progress_cb=write_progress, no_device=self.options.dummy, prnfile=self.options.prnfile)
     except Exception as e:
       print >>self.tty, e
       print >>sys.stderr, e


### PR DESCRIPTION
Sometimes it would be nice to cut remotely or across a network. This set of changes adds the ability to "cut to file" so you can dump it to the cutter elsewhere. It works by adding a dummy PrnFile class which fakes and removes the status commands while writing actual cut data to file. An option for filepath is provided.

Note it does not create a GSD file suitable for putting on an SD card unfortunately. That would have been nice too but the raw cut data is not the same as the GSD format.

You can send the prnfile data using your typical cat or echo command (on linux, probably different on other OS). eg. `cat test.cut > /dev/usb/lp1` (that worked for me once I added myself to lp group).

My main reason for wanting this was so I can put the cutter in the "noisy room" with 3D printer hanging off a raspberry pi but still do design work on my laptop in a quieter room. But it will work also when you want to save cut jobs for later use and just send them rather than opening inkscape. So it is nice for automated repetitive tasks as well.

It would be nice to add a file chooser for selecting output filename but I stopped short due to work required to research and figure that out.

Hope this is as useful for others as for me. Cheers.