### PR TITLE
Inkscape v1.00 compatibility updates

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -130,7 +130,7 @@ Always use the least amount of blade possible.
     <page name='about' _gui-text='About'>
       <param name="about_who" type="description">inkscape-silhouette extension from https://github.com/jnweiger/inkscape-silhouette by Jürgen Weigert [juergen@fabmail.org] and contributors</param>
       <!-- Keep in sync with sendto_silhouette.py line 78 __version__ = ... -->
-      <param name="about_version" type="description">Version 1.21</param>
+      <param name="about_version" type="description">Version 1.23</param>
     </page>
   </param>
 

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -222,7 +222,7 @@ class SilhouetteCameo:
         try:
             for dev in usb.core.find(find_all=True):
               msg += "(%04x,%04x) " % (dev.idVendor, dev.idProduct)
-        except NameError: 
+        except NameError:
             msg += "unable to list devices on OS X"
         raise ValueError('No Graphtec Silhouette devices found.\nCheck USB and Power.\nDevices: '+msg)
 
@@ -409,7 +409,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     elif isinstance(data, bytearray):
         return str(data).decode()
     else:
-        return data.tostring().decode()
+        return data.tobytes().decode()  # return data.tostring().decode()
 
   def try_read(s, size=64, timeout=1000):
     ret=None
@@ -690,7 +690,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     s.enable_sw_clipping = sw_clipping
 
     # if enabled, rollers three times forward and back.
-    # needs a pressure of 19 or more, else nothing will happen 
+    # needs a pressure of 19 or more, else nothing will happen
     if trackenhancing is not None:
       if trackenhancing:
         s.write(b"FY0\x03")
@@ -958,7 +958,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       #resp = s.read(timeout=40000) ## Allow 20s for reply...
       #if resp != "    0\x03":
         #raise ValueError("Couldn't find registration marks. (2)(%s)" % str(resp))
-      
+
       #resp = s.read(timeout=40000) ## Allow 20s for reply...
       #if resp != "    1\x03":
         #raise ValueError("Couldn't find registration marks. (3)")
@@ -975,7 +975,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     #\xmin, ymin Zxmax,ymax, designate cutting area
 
     # needed only for the trackenhancing feature, defines the usable length, rollers three times forward and back.
-    # needs a pressure of 19 or more, else nothing will happen 
+    # needs a pressure of 19 or more, else nothing will happen
     #p = b"FU%d\x03" % (height)
     #p = b"FU%d,%d\x03" % (height,width) # optional
     #s.write(p)
@@ -1038,7 +1038,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     for line in open(file,'r').readlines():
       if re.match(r'\s*\[', line):
         exec('data1234='+line)
-        break 
+        break
       elif re.match(r'\s*<\s*svg', line):
         print(line)
         print("Error: xml/svg file. Please load into inkscape. Use extensions -> export -> sendto silhouette, [x] dump to file")


### PR DESCRIPTION
These changes get rid of all* deprecation warnings when running inkscape-silhouette on inkscape version 1.00.

I figured I send this out here for folks that were forced onto inkscape v1 and ran into issues with their silhouette cutter. Since the changes are likely not backwards compatible with 0.92 or even python2 I suspect you don't want to just integrate this. Let's either have a conversation about how to make this acceptable or use it as a simple guide to get the changes made properly by someone else.

It also fixes parts or all of issues #101 and #90, at least for me.

Disclaimers:
* Tested successfully on Inkscape v1.00, python3 and Silhouette Cameo 3. 
* Only tested with my typical workflows
* Didn't touch other files that probably need updating as well (e.g. silhouette_multi.py)
* Not tested on inkscape 0.92 and/or python2
