### PR TITLE
Fix str object has no decode() method error. Follow-up on #94

### DIFF
--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -404,10 +404,8 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
             data = s.dev.bulkRead(endpoint, size, timeout=timeout)
     if data is None:
       raise ValueError('read failed: none')
-    if isinstance(data, (str, bytes)):
+    if isinstance(data, (str, bytes, bytearray)):
         return data.decode()
-    elif isinstance(data, bytearray):
-        return str(data).decode()
     else:
         return data.tostring().decode()
 


### PR DESCRIPTION
On OSX the bulkRead method is used. That returns a bytearray. The elif branch gets triggered, which, when using Python3 (and Inkscape 0.92.5), fails as the constructed str object (by calling str(data)) does not posses a decode() method in Python3 any more. I don't saw any reason why we should not handle the bytearray case similarly to the str and bytes case.

Please correct me if I am wrong and we indeed need to handle this case separately.