### PR TITLE
Allow speed up to 30 for cameo 4

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -55,7 +55,7 @@
         <item value="137">[P=30,S=10] Vellum Bristol 57-67 lbs (145g)</item>
         <item value="138">[P=30,S=10] Writing Paper 24-70 lbs (105g)</item>
       </param>
-      <param name="speed" type="int" min="0" max="10" _gui-text="Speed">0</param>
+      <param name="speed" type="int" min="0" max="30" _gui-text="Speed">0</param>
       <param name="pressure" type="int" min="0" max="33" _gui-text="Pressure">0</param>
       <param name="depth" type="int" min="-1" max="10" _gui-text="Blade Depth (for AutoBlade)">-1</param>
       <param name="speed_help" type="description">Use speed=0, pressure=0, depth=-1 to take the media defaults. Pressure values of 19 or more could trigger the trackenhancing feature, which means a movement along the full media height before start. Beware.</param>
@@ -140,7 +140,7 @@ Always use the least amount of blade possible.
       <submenu _name="Export"/>
     </effects-menu>
   </effect>
-  
+
   <script>
       <command reldir="extensions" interpreter="python">sendto_silhouette.py</command>
   </script>

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -749,7 +749,8 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
         media : int, optional
             range is [100..300], "Print Paper Light Weight". Defaults to 132.
         speed : int, optional
-            range is [1..10]. Defaults to None, from paper (132 -> 10).
+            range is [1..10] for Cameo3 and older, 
+            range is [1..30] for Cameo4. Defaults to None, from paper (132 -> 10).
         pressure : int, optional
             range is [1..33], Notice: Cameo runs trackenhancing if you select a pressure of 19 or more. Defaults to None, from paper (132 -> 5).
         toolholder : int, optional

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -837,7 +837,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
 
       if speed is not None:
         if speed < 1: speed = 1
-        if speed > 10: speed = 10
+        if speed > 30: speed = 30
         self.send_command(tool.speed(speed))
         print("speed: %d" % speed, file=self.log)
 


### PR DESCRIPTION
The Cameo 4 appears to allow speeds up to 30 on both tools rather than just 10.

![studio_speed30](https://user-images.githubusercontent.com/322473/115144249-95b74100-a043-11eb-9a60-78dbf3cc9626.png)

Confirmed by setting it in silhouette Studio and dumping usb traffic under windows:

```
0000   80 f4 35 87 79 a0 ff ff 53 03 01 06 01 00 2d 00   ..5.y...S.....-.
0010   1f 15 7c 60 00 00 00 00 b9 a7 05 00 8d ff ff ff   ..|`............
0020   1e 00 00 00 1e 00 00 00 00 00 00 00 00 00 00 00   ................
0030   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
0040   46 58 39 2c 31 03 54 4a 30 03 21 33 30 2c 31 03   FX9,1.TJ0.!30,1.
0050   46 43 30 2c 31 2c 31 03 46 45 30 2c 31 03         FC0,1,1.FE0,1.
```