### PR TITLE
feat: add optional file in which to save all log messages

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -106,6 +106,7 @@
       <param name="sw_clipping" type="boolean" _gui-text="Enable Software Clipping">true</param>
       <param name="dummy"    type="boolean" _gui-text="Dummy device: Send to /tmp/silhouette.dump">false</param>
       <param name="dummy_help" type="description">Used for debugging and developent only!</param>
+      <param name="logfile" type="string" _gui-text="Save log messages in file:"></param>
     </page>
 
     <page name='blade' _gui-text='Blade Setting'>


### PR DESCRIPTION
I am working on a few enhancements to inkscape_silhouette for the Cameo 4 Pro, but to understand and debug the code, it's very important to be able to see the log messages. I can't seem to grab what's currently being directed to the "tty", so I thought I would start with a small patch that adds an option to also save all of the log messages to a file.