### PR TITLE
(Do not merge) First pass at enhancing logging and dumping features

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -104,9 +104,13 @@
       <param name="mintravel_help" type="description">Minimal Traveling: Find the nearest startpoint to minimize travel movements</param>
       <param name="mintravelfull_help" type="description">Minimal Traveling (fully optimized): Additionally search startpoints in closed paths</param>
       <param name="sw_clipping" type="boolean" _gui-text="Enable Software Clipping">true</param>
-      <param name="dummy"    type="boolean" _gui-text="Dummy device: Send to /tmp/silhouette.dump">false</param>
-      <param name="dummy_help" type="description">Used for debugging and developent only!</param>
+    </page>
+    <page name='logdump' _gui-text='Log and Dump'>
       <param name="logfile" type="string" _gui-text="Save log messages in file:"></param>
+      <param name="log_paths" type="boolean" _gui-text="Include final cut paths in log (for debugging)">false</param>
+      <param name="cmdfile" type="string" _gui-text="Transcribe cutter commands to file:"></param>
+      <param name="inc_queries" type="boolean" _gui-text="Include cutter queries in command transcript">false</param>
+      <param name="dry_run" type="boolean" _gui-text="Dry Run: do not send commands to device">false</param>
     </page>
 
     <page name='blade' _gui-text='Blade Setting'>

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -283,8 +283,6 @@ class SendtoSilhouette(inkex.Effect):
         self.docHeight = N_PAGE_HEIGHT
         self.docTransform = IDENTITY_TRANSFORM
 
-        self.dumpname= os.path.join(tempfile.gettempdir(), "silhouette.dump")
-
         try:
             self.tty = open("/dev/tty", "w")
         except:
@@ -329,9 +327,12 @@ class SendtoSilhouette(inkex.Effect):
         self.arg_parser.add_argument("-D", "--depth",
                 dest = "depth", type = int, default = -1,
                 help="[0..10], or -1 for media default")
-        self.arg_parser.add_argument("--dummy",
-                dest = "dummy", type = inkex.Boolean, default = False,
-                help="Dump raw data to "+self.dumpname+" instead of cutting.")
+        self.arg_parser.add_argument("--log_paths",
+                dest = "logpaths", type = inkex.Boolean, default = False,
+                help="Include final cut paths in log.")
+        self.arg_parser.add_argument("--dry_run",
+                dest = "dry_run", type = inkex.Boolean, default = False,
+                help="Suppress sending commands to device.")
         self.arg_parser.add_argument("-g", "--strategy",
                 dest = "strategy", default = "mintravel",
                 choices=("mintravel", "mintravelfull", "matfree", "zorder"),
@@ -402,6 +403,12 @@ class SendtoSilhouette(inkex.Effect):
         self.arg_parser.add_argument("-e", "--endposition", "--end-postition",
                 "--end_position", choices=("start", "below"),
                 dest = "endposition", default = "below", help="Position of head after cutting: start or below")
+        self.arg_parser.add_argument("--cmdfile",
+                dest = "cmdfile", default = None,
+                help="Name of file to save transcript of cutter commands.")
+        self.arg_parser.add_argument("--inc_queries",
+                dest = "inc_queries", type = inkex.Boolean, default = False,
+                help="Include queries in cutter command transcript")
         self.arg_parser.add_argument("--logfile",
                 dest = "logfile", default = None,
                 help="Name of file in which to save log messages.")
@@ -1085,7 +1092,10 @@ class SendtoSilhouette(inkex.Effect):
             self.log = teeFile(self.tty, open(self.options.logfile, "w"))
 
         try:
-            dev = SilhouetteCameo(log=self.log, progress_cb=write_progress, no_device=self.options.dummy)
+            dev = SilhouetteCameo(log=self.log, progress_cb=write_progress,
+                                  dry_run=self.options.dry_run,
+                                  cmdfile=self.options.cmdfile,
+                                  inc_queries=self.options.inc_queries)
         except Exception as e:
             print(e, file=self.tty)
             print(e, file=sys.stderr)
@@ -1190,7 +1200,7 @@ class SendtoSilhouette(inkex.Effect):
 
             cut.append(multipath)
 
-        if dev.dev is None:
+        if self.options.logpaths:
             docname=None
             svg = self.document.getroot()
             # Namespace horrors: Id's expand to full urls, before we can search them.
@@ -1199,18 +1209,14 @@ class SendtoSilhouette(inkex.Effect):
                 if re.search(r"}docname$", tag):
                     docname=svg.get(tag)
 
-            o = open(self.dumpname, "w")
-            print("Dump written to ", self.dumpname, " (", pointcount, " points)", file=self.log)
-            print("Dump written to ", self.dumpname, " (", pointcount, " points)", file=sys.stderr)
-            print("device version: '%s'" % dev.get_version(), file=sys.stderr)
-            print("driver version: '%s'" % __version__, file=sys.stderr)
-            print("# device version: '%s'" % dev.get_version(), file=o)
-            print("# driver version: '%s'" % __version__, file=o)
+            print("Logging cut paths containing", pointcount, " points:",
+                  file=self.log)
+            print("# device version: '%s'" % dev.get_version(), file=self.log)
+            print("# driver version: '%s'" % __version__, file=self.log)
             if docname:
-                    print("# docname: '%s'" % docname, file=o)
-                    print("docname: '%s'" % docname, file=sys.stderr)
-            print(cut, file=o)
-            o.close()
+                    print("# docname: '%s'" % docname, file=self.log)
+            print(cut, file=self.log)
+            print("# End of cut paths", file=self.log)
 
         if self.options.pressure == 0:
             self.options.pressure = None

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -57,9 +57,8 @@ class TestRun(unittest.TestCase):
 
     def test_04dummy_cut(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dummy=True", "examples/testcut_square_triangle.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dry_run=True", "examples/testcut_square_triangle.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
-            self.assertIn('Dump written to', str(result))
         except subprocess.CalledProcessError as e:
             print(e.output.decode())
             print(e)
@@ -69,9 +68,8 @@ class TestRun(unittest.TestCase):
 
     def test_05dummy_cut(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dummy=True", "examples/testcut_square_triangle_o.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dry_run=True", "examples/testcut_square_triangle_o.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
-            self.assertIn('Dump written to', str(result))
         except subprocess.CalledProcessError as e:
             print(e.output.decode())
             print(e)
@@ -81,9 +79,8 @@ class TestRun(unittest.TestCase):
 
     def test_06dummy_cut(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dummy=True", "examples/sharp_turns.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dry_run=True", "examples/sharp_turns.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
-            self.assertIn('Dump written to', str(result))
         except subprocess.CalledProcessError as e:
             print(e.output.decode())
             print(e)
@@ -93,9 +90,8 @@ class TestRun(unittest.TestCase):
 
     def test_07dummy_cut(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dashes=True", "--dummy=True", "examples/dashline.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dashes=True", "--dry_run=True", "examples/dashline.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
-            self.assertIn('Dump written to', str(result))
         except subprocess.CalledProcessError as e:
             print(e.output.decode())
             print(e)


### PR DESCRIPTION
This PR is inspired by and intends to replace #69. Many thanks to @neocogent for the model. I am doing a large production run of identical pieces on my Cameo 4 Pro and so need the commands in a file to be sent repeatedly. The main differences from #69 are as follows:

- Based on current "master" branch (By the way, please would you consider renaming this branch to "main" as part of the effort to make tech language more inclusive?)
- Makes whether the commands are captured independent of whether they are being sent to the cutter (so you can capture the commands on a "live" run as well)
- Still queries for a device when dumping, as the identity of the device can affect the commands produced.
- Allows you to toggle whether the queries to the device are included in the command capture, or just the directives.

In addition, this PR allows both a dump of the raw paths and a capture of the cutter commands on the same run. Since the raw paths are primarily for debugging, once there were files for the log and the commands, it seemed excessive to have a third file for the paths, so I moved those to the log, which simplified the code in that a separate tempfile did not then have to be generated for them. (If it's important that the paths dump goes into a separate file, just let me know and I can revert that bit of the changes.)

Finally, because there are now several options related to logging and dumping, this PR moves those controls to their own page in the GUI.