### PR TITLE
feat: Greater control over orientations of paths

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -103,6 +103,14 @@
       <param name="mat_free_help" type="description">Without mat: Subdivide, sort, and choose cut directions, so that a cutting mat is not needed in most cases.</param>
       <param name="mintravel_help" type="description">Minimal Traveling: Find the nearest startpoint to minimize travel movements</param>
       <param name="mintravelfull_help" type="description">Minimal Traveling (fully optimized): Additionally search startpoints in closed paths</param>
+      <param name="orient_paths" type="enum" _gui-text="Pre-orient paths:">
+	<item value="natural">As in SVG</item>
+	<item value="desy">Descending Y (pull through tool)</item>
+	<item value="ascy">Ascending Y (push into tool)</item>
+	<item value="desx">Descending X (right to left)</item>
+	<item value="ascx">Ascending X (left to right)</item>
+      </param>
+      <param name="orient_help1" type="description">Note: Some strategies like "Without Mat" may reverse some path orientations, so final cut may not strictly obey orientation chosen above.</param>
       <param name="sw_clipping" type="boolean" _gui-text="Enable Software Clipping">true</param>
       <param name="dummy"    type="boolean" _gui-text="Dummy device: Send to /tmp/silhouette.dump">false</param>
       <param name="dummy_help" type="description">Used for debugging and developent only!</param>

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -98,11 +98,13 @@
         <item value="matfree">Without mat</item>
         <item value="mintravel">Minimized Traveling</item>
         <item value="mintravelfull">Minimized Traveling (fully optimized)</item>
+        <item value="mintravelfwd">Minimized Traveling (no reverse)</item>
       </param>
       <param name="zorder_help" type="description">Z-Order: Leaf cut order as defined in input svg.</param>
       <param name="mat_free_help" type="description">Without mat: Subdivide, sort, and choose cut directions, so that a cutting mat is not needed in most cases.</param>
       <param name="mintravel_help" type="description">Minimal Traveling: Find the nearest startpoint to minimize travel movements</param>
       <param name="mintravelfull_help" type="description">Minimal Traveling (fully optimized): Additionally search startpoints in closed paths</param>
+      <param name="mintravelfwd_help" type="description">Minimal Traveling (no reverse): Like fully optimized but respect original orientations of paths</param>
       <param name="orient_paths" type="enum" _gui-text="Pre-orient paths:">
 	<item value="natural">As in SVG</item>
 	<item value="desy">Descending Y (pull through tool)</item>

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -334,8 +334,8 @@ class SendtoSilhouette(inkex.Effect):
                 help="Dump raw data to "+self.dumpname+" instead of cutting.")
         self.arg_parser.add_argument("-g", "--strategy",
                 dest = "strategy", default = "mintravel",
-                choices=("mintravel", "mintravelfull", "matfree", "zorder"),
-                help="Cutting Strategy: mintravel, mintravelfull, matfree or zorder")
+                choices=("mintravel", "mintravelfull", "mintravelfwd", "matfree", "zorder"),
+                help="Cutting Strategy: mintravel, mintravelfull, mintravelfwd, matfree or zorder")
         self.arg_parser.add_argument("--orient_paths",
                 dest = "orient_paths", default = "natural",
                 choices=("natural","desy","ascy","desx","ascy"),
@@ -1165,7 +1165,9 @@ class SendtoSilhouette(inkex.Effect):
         elif self.options.strategy == "mintravel":
             self.paths = silhouette.StrategyMinTraveling.sort(self.paths)
         elif self.options.strategy == "mintravelfull":
-            self.paths = silhouette.StrategyMinTraveling.sort(self.paths, True)
+            self.paths = silhouette.StrategyMinTraveling.sort(self.paths, entrycircular=True)
+        elif self.options.strategy == "mintravelfwd":
+            self.paths = silhouette.StrategyMinTraveling.sort(self.paths, entrycircular=True, reversible=False)
         # in case of zorder do no reorder
 
         # print(self.paths, file=self.tty)

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -338,7 +338,7 @@ class SendtoSilhouette(inkex.Effect):
                 help="Cutting Strategy: mintravel, mintravelfull, mintravelfwd, matfree or zorder")
         self.arg_parser.add_argument("--orient_paths",
                 dest = "orient_paths", default = "natural",
-                choices=("natural","desy","ascy","desx","ascy"),
+                choices=("natural","desy","ascy","desx","ascx"),
                 help="Pre-orient paths: natural (as in svg), or [des(cending)|asc(ending)][y|x]")
         self.arg_parser.add_argument("-l", "--sw_clipping",
                 dest = "sw_clipping", type = inkex.Boolean, default = True,
@@ -1144,6 +1144,9 @@ class SendtoSilhouette(inkex.Effect):
                         if len(newpath) == 1:
                             # Have to make some progress:
                             newpath = [curpath[-1], newpath[0]]
+                            # Don't leave behind an orphan
+                            if len(curpath) == 1:
+                                curpath = []
                         else:
                             # Have to put end of newpath back onto curpath to
                             # keep the segment between it and rest of curpath:

--- a/silhouette/StrategyMinTraveling.py
+++ b/silhouette/StrategyMinTraveling.py
@@ -17,7 +17,7 @@ def dist_sq(a,b):
 
 
 # Finds the nearest path in a list from a given position
-def findnearestpath(paths, pos, entrycircular=False):
+def findnearestpath(paths, pos, entrycircular, reversible):
     nearestindex=0
     nearestdist=float("inf")
     for index,path in enumerate(paths):
@@ -26,11 +26,12 @@ def findnearestpath(paths, pos, entrycircular=False):
             nearestdist = distance
             nearestindex = index
             selected = path
-        distance = dist_sq(pos,path[-1]) # reverse direction
-        if (nearestdist > distance):
-            nearestdist = distance
-            nearestindex = index
-            selected = path[::-1]
+        if reversible:
+            distance = dist_sq(pos,path[-1]) # reverse direction
+            if (nearestdist > distance):
+                nearestdist = distance
+                nearestindex = index
+                selected = path[::-1]
         if (entrycircular & (path[0] == path[-1])):  # break up circular path. Not sure, if this saves real much time
            for i,p in enumerate(path):   # test each point in closed path
                  distance = dist_sq(pos,p)
@@ -41,12 +42,13 @@ def findnearestpath(paths, pos, entrycircular=False):
     return nearestindex,selected
 
 
-# Sort paths to achieve minimal traveling times
-def sort(paths, entrycircular=False):
+# Sort paths to approximate minimal traveling times
+# (greedy algorithm not necessarily optimal)
+def sort(paths, entrycircular=False, reversible=True):
     pos=(0,0)
     sortedpaths=[]
     while (len(paths) > 0):
-        i,path = findnearestpath(paths,pos,entrycircular)
+        i,path = findnearestpath(paths,pos,entrycircular,reversible)
         paths.pop(i)             # delete found index
         pos = path[-1]           # endpoint is next start point for search
         sortedpaths.append(path) # append to output list


### PR DESCRIPTION
This PR adds an option to pre-orient paths to be monotone in either the Y or X direction. The motivating use case here is that I am using the Cameo to score without a mat, and this only works if the material is pulled through the tool (descending Y coordinate); it is impossible to _push_ a flexible, unbacked material into a scoring tool.

It also adds a variant of the MinTravel strategy which declines to reverse the orientation of any paths it is given. That variant of the strategy is more useful when path orientations are critical.

As before, this PR is totally independent of #138, but I did make use of the features of #138 in developing this.