### PR TITLE
Allow device queries in dry_run mode

### DIFF
--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -332,7 +332,7 @@ class SendtoSilhouette(inkex.Effect):
                 help="Include final cut paths in log")
         self.arg_parser.add_argument("--dry_run",
                 dest = "dry_run", type = inkex.Boolean, default = False,
-                help="Do not communicate with device")
+                help="Do not send commands to device (queries allowed)")
         self.arg_parser.add_argument("-g", "--strategy",
                 dest = "strategy", default = "mintravel",
                 choices=("mintravel", "mintravelfull", "mintravelfwd", "matfree", "zorder"),
@@ -1090,7 +1090,7 @@ class SendtoSilhouette(inkex.Effect):
             self.log = teeFile(self.tty, open(self.options.logfile, "w"))
 
         try:
-            dev = SilhouetteCameo(log=self.log, progress_cb=write_progress, no_device=self.options.dry_run)
+            dev = SilhouetteCameo(log=self.log, progress_cb=write_progress, dry_run=self.options.dry_run)
         except Exception as e:
             print(e, file=self.tty)
             print(e, file=sys.stderr)


### PR DESCRIPTION
Continuing the series of PRs to build up the functionality of #138. This one is primarily preparation for the transcription of command files. However, I've split it out as a separate PR because this is the change that entails the most significant low-level alterations: all of the low-level read/writes must now operate without a device, mocking up a perpetual 'ready' state and returning a dummy string when the device firmware version is queried. To facilitate and clarify this operation, the low-level routines now operate specifically with byte strings, and just the higher-level routines (like send_receive_command) deal in ordinary Python strings.

Hence, it seemed as though whatever issue was causing the Python 2 umockdev failure in #138, if it is going to recur with this restructuring of the changes, would be most likely to occur in this PR.

This PR is built on #140 and should be a fast-forward if/when that is merged.