### PR TITLE
feat: Option to save all cutter commands to file.

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -114,9 +114,14 @@
       </param>
       <param name="orient_help1" type="description">Note: Some strategies like "Without Mat" may reverse some path orientations, so final cut may not strictly obey orientation chosen above.</param>
       <param name="sw_clipping" type="boolean" _gui-text="Enable Software Clipping">true</param>
-      <param name="log_paths" type="boolean" _gui-text="Include final cut paths in log (for debugging)">false</param>
-      <param name="dry_run" type="boolean" _gui-text="Dry Run: do not communicate with device">false</param>
+    </page>
+
+    <page name="logdump" _gui-text="Log and Dump">
       <param name="logfile" type="string" _gui-text="Save log messages in file:"></param>
+      <param name="log_paths" type="boolean" _gui-text="Include final cut paths in log (for debugging)">false</param>
+      <param name="cmdfile" type="string" _gui-text="Transcribe cutter commands to file:"></param>
+      <param name="inc_queries" type="boolean" _gui-text="Include cutter queries in command transcript">false</param>
+      <param name="dry_run" type="boolean" _gui-text="Dry Run: do not send commands to device">false</param>
     </page>
 
     <page name='blade' _gui-text='Blade Setting'>

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -410,6 +410,12 @@ class SendtoSilhouette(inkex.Effect):
         self.arg_parser.add_argument("--logfile",
                 dest = "logfile", default = None,
                 help="Name of file in which to save log messages.")
+        self.arg_parser.add_argument("--cmdfile",
+                dest = "cmdfile", default = None,
+                help="Name of file to save transcript of cutter commands.")
+        self.arg_parser.add_argument("--inc_queries",
+                dest = "inc_queries", type = inkex.Boolean, default = False,
+                help="Include queries in cutter command transcript")
         # Can't set up the log here because arguments have not yet been parsed;
         # defer that to the top of the effect() method, which is where all
         # of the real activity happens.
@@ -1090,7 +1096,10 @@ class SendtoSilhouette(inkex.Effect):
             self.log = teeFile(self.tty, open(self.options.logfile, "w"))
 
         try:
-            dev = SilhouetteCameo(log=self.log, progress_cb=write_progress, dry_run=self.options.dry_run)
+            dev = SilhouetteCameo(log=self.log, progress_cb=write_progress,
+                                  cmdfile=self.options.cmdfile,
+                                  inc_queries=self.options.inc_queries,
+                                  dry_run=self.options.dry_run)
         except Exception as e:
             print(e, file=self.tty)
             print(e, file=sys.stderr)


### PR DESCRIPTION
Culmination of dividing #138 into three separate PRs. This is built on top of #142 and adds the real target feature: saving of cutter commands to a file. This can be done in a dry run and sent to the cutter later, or captured from a live run to be re-sent to make copies.

Ah, should I add documentation somewhere that on linux at least, saved commands can be later executed by the cutter by sending them to the appropriate /dev/usb/lpX file? If so, where should that information go?

For me, this feature will greatly enhance the usefulness of inkscape_silhouette, since I often make numerous copies of the same cut. Thank you for working with me on it.