### PR TITLE
feat: add option to fuse paths to reduce tool lifting

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -113,6 +113,8 @@
 	<item value="ascx">Ascending X (left to right)</item>
       </param>
       <param name="orient_help1" type="description">Note: Some strategies like "Without Mat" may reverse some path orientations, so final cut may not strictly obey orientation chosen above.</param>
+      <param name="fuse_paths" type="boolean" _gui-text="Fuse coincident paths">true</param>
+      <param name="fuse_help" type="description">Merges consecutive paths that end and start with same point to minimize tool lifting. (Most effective with the Min Travel strategies.)</param>
       <param name="sw_clipping" type="boolean" _gui-text="Enable Software Clipping">true</param>
       <param name="log_paths" type="boolean" _gui-text="Include final cut paths in log (for debugging)">false</param>
       <param name="dry_run" type="boolean" _gui-text="Dry Run: do not communicate with device">false</param>

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -341,6 +341,9 @@ class SendtoSilhouette(inkex.Effect):
                 dest = "orient_paths", default = "natural",
                 choices=("natural","desy","ascy","desx","ascx"),
                 help="Pre-orient paths: natural (as in svg), or [des(cending)|asc(ending)][y|x]")
+        self.arg_parser.add_argument("--fuse_paths",
+                dest = "fuse_paths", type = inkex.Boolean, default = True,
+                help="Merge any path with predecessor that ends at its start.")
         self.arg_parser.add_argument("-l", "--sw_clipping",
                 dest = "sw_clipping", type = inkex.Boolean, default = True,
                 help="Enable software clipping")
@@ -1173,6 +1176,15 @@ class SendtoSilhouette(inkex.Effect):
         elif self.options.strategy == "mintravelfwd":
             self.paths = silhouette.StrategyMinTraveling.sort(self.paths, entrycircular=True, reversible=False)
         # in case of zorder do no reorder
+
+        if self.paths and self.options.fuse_paths:
+            rest_paths = self.paths[1:]
+            self.paths = [self.paths[0]]
+            for path in rest_paths:
+                if path[0] == self.paths[-1][-1]:
+                    self.paths[-1].extend(path[1:])
+                else:
+                    self.paths.append(path)
 
         # print(self.paths, file=self.tty)
         cut = []


### PR DESCRIPTION
I am working with cut files produced as dxf files in a CAD program, and the conversion process to svg that's provided in that program produces files that have many individual segments rather than paths of connected segments. This is causing a lot of the tool bobbing up and down, which makes the cutting take noticeably longer. This PR adds an option to fuse paths when one ends at the same point that the next starts, which greatly reduces tool motion in my case. Since it seems to be an innocuous operation to fuse paths in this way, I have made the option default to True (although I have left it as a selectable option in the Advanced tab, so that it can be turned off to regain the prior behavior of leaving paths separate, in case that's needed in some application.)