### PR TITLE
Py39 fixes

### DIFF
--- a/misc/arrow_test.py
+++ b/misc/arrow_test.py
@@ -22,10 +22,10 @@ print("status=%s" % dev.wait_for_ready(20))
 
 tmp_fwd=85	# enough to show 20mm of the latest drawing on the far side of the device.
 
-dev.setup(media=113, pressure=0, trackenhancing=True, return_home=False)
+dev.setup(media=113, pressure=0, trackenhancing=True)
 
 for i in range(8):
-  bbox = dev.plot(pathlist=[ arrow1,[(0,tmp_fwd),(0,tmp_fwd)] ], mediaheight=180, offset=(60,0), bboxonly=False, end_paper_offset=-tmp_fwd+1, no_trailer=True)
+  bbox = dev.plot(pathlist=[ arrow1,[(0,tmp_fwd),(0,tmp_fwd)] ], mediaheight=180, offset=(60,0), bboxonly=False, end_paper_offset=-tmp_fwd+1)
   dev.wait_for_ready()
   print(i, "path done.")
   time.sleep(5)

--- a/misc/endless_clock.py
+++ b/misc/endless_clock.py
@@ -22,7 +22,7 @@ sys.path.extend(['..','.'])	# make it callable from top or misc directory.
 from silhouette.Graphtec import SilhouetteCameo
 
 dev = SilhouetteCameo()
-dev.setup(media=113, pressure=1, trackenhancing=True, return_home=True)	# 113 = Pen
+dev.setup(media=113, pressure=1, trackenhancing=True)	# 113 = Pen
 
 time_window=60		# show the clock every N seconds.
 clock_margin=30		# mm kept clear for clock
@@ -232,7 +232,7 @@ while True:
   clock_path_origin = []
   for poly in clock_path: clock_path_origin.append(translate_poly(poly, -cbox['llx'], -cbox['ury']+cy_off))
   clock_path_origin.append([(0,tmp_fwd+cy_off),(0,tmp_fwd+cy_off)])
-  meta = dev.plot(pathlist=clock_path_origin, offset=(0,0), no_trailer=True)
+  meta = dev.plot(pathlist=clock_path_origin, offset=(0,0))
   dev.wait_for_ready()
   time.sleep(2)	# show the time before doing something else.
   cy_off += int(ystep*1.2)

--- a/misc/silhouette_cut.py
+++ b/misc/silhouette_cut.py
@@ -20,21 +20,20 @@ ArgParser.add_argument('-y', '--yoff', type=float, default=0.0, help="Vertical o
 #ArgParser.add_argument('-S', '--scale',type=float, default=1.0, help="Scale the design.")
 ArgParser.add_argument('-p', '--pressure', type=int, default=3, help="Pressure value [1..18]")
 ArgParser.add_argument('-s', '--speed', type=int, default=10, help="Speed value [1..10]")
-ArgParser.add_argument('-a', '--advance-origin', action='store_true', help="Set the origin below the design. Default: return home.")
 ArgParser.add_argument('-W', '--width', type=float, default=210.0, help="Media width [mm].")
 ArgParser.add_argument('-H', '--height', type=float, default=297.0, help="Media height [mm].")
 ArgParser.add_argument('dumpfile')
 args = ArgParser.parse_args()
 
 dev = SilhouetteCameo()
-dev.setup(speed=args.speed, pressure=args.pressure, pen=args.pen, return_home=(not args.advance_origin))
+dev.setup(speed=args.speed, pressure=args.pressure, pen=args.pen)
 
 # print args
 
 dumpdata=dev.load_dumpfile(args.dumpfile)
 
 dev.wait_for_ready()
-meta = dev.plot(pathlist=[], bboxonly=args.bbox, no_trailer=True,
+meta = dev.plot(pathlist=[], bboxonly=args.bbox,
                 mediawidth=args.width, mediaheight=args.height, offset=(args.xoff,args.yoff))
 print(meta)
 

--- a/misc/silhouette_move.py
+++ b/misc/silhouette_move.py
@@ -7,7 +7,7 @@
 
 from __future__ import print_function
 
-import time,sys,string
+import sys
 
 sys.path.extend(['..','.'])	# make it callable from top or misc directory.
 from silhouette.Graphtec import SilhouetteCameo
@@ -16,7 +16,7 @@ dev = SilhouetteCameo()		# no dev.setup() needed here.
 
 feed_mm = 10
 if len(sys.argv) > 1:
-  feed_mm = string.atof(sys.argv[1])
+  feed_mm = float(sys.argv[1])
 
 if not feed_mm:
   print("Usage: %s [PAPER_FORWARD_MM]" % sys.argv[0])

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -694,7 +694,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       pass
     if resp[-1] != CMD_ETX[0]:
       raise ValueError('status response not terminated with 0x03: %s' % (resp[-1]))
-    return RESP_DECODING.get(resp[:-1], resp[:-1])
+    return RESP_DECODING.get(bytes(resp[:-1]), bytes(resp[:-1]))
 
   def get_tool_setup(self):
     """ gets the type of the tools installed in Cameo 4 """


### PR DESCRIPTION
Hi,

Trying a newly acquired secondhand Silhouette Portrait (1st gen) on OSX, inkscape-silhouette first crashed with `TypeError: unhashable type:  'bytearray'` while calling `RESP_DECODING.get()` with data from libusb.

Not having any clue if it was normal or not I tried running scripts from the `misc` folder, which failed for this reason and other ones.

The proposed commits fix the problem with `RESP_DECODING.get()` and some other small fixes in `misc` scripts about Python3 or deprecated functions from inkscape-silhouette.

Great work otherwise, this extension works like a charm for now with my new (although old-ish) device !

Environment details:
- OSX x86_64
- libusb 1.0.24 (from brew)
- Python 3.9.5 (from brew)
  - libusb1==1.9.2 (from pip)
  - pyusb==1.1.1 (from pip)