### PR TITLE
feat: Provide GUI control for end_paper_offset

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -74,6 +74,8 @@
         <item value="below">Below Cut-Out</item>
       </param>
       <param name="endposition_help" type="description">Choose position of blade relative to the media after cutting. "Below Cut-Out" is ideal for using cross-cutter.</param>
+      <param name="end_offset" type="float" min="-3000.0" max="3000.0" _gui-text="End Position Offset [mm]:">0.0</param>
+      <param name="end_off_help" type="description">Adjusts the final position selected above; currently only implemented for "Below Cut-Out". Allows you to leave space between cuts (or with a negative value, position above the bottom of the cut, which can reduce wasted material for repeating certain patterns).</param>
     </page>
 
     <page name='reg' _gui-text='Regmarks'>

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -414,6 +414,9 @@ class SendtoSilhouette(inkex.Effect):
         self.arg_parser.add_argument("-e", "--endposition", "--end-postition",
                 "--end_position", choices=("start", "below"),
                 dest = "endposition", default = "below", help="Position of head after cutting: start or below")
+        self.arg_parser.add_argument("--end_offset", type = float,
+                dest = "end_offset", default = 0.0,
+                help="Adjustment to the position after cutting")
         self.arg_parser.add_argument("--logfile",
                 dest = "logfile", default = None,
                 help="Name of file in which to save log messages.")
@@ -1326,6 +1329,7 @@ class SendtoSilhouette(inkex.Effect):
             offset=(self.options.x_off, self.options.y_off),
             bboxonly=self.options.bboxonly,
             endposition=self.options.endposition,
+            end_paper_offset=self.options.end_offset,
             regmark=self.options.regmark,
             regsearch=self.options.regsearch,
             regwidth=self.options.regwidth,


### PR DESCRIPTION
I spoke too soon about no more PRs.  I need to adjust the spacing between multiple copies of my cut. Turns out the device plot function (in Graphtec.py) already has an option for this, `end_paper_offset`, but there's no GUI setting for it. All this PR does is make it possible to set the `end_paper_offset` through the inkscape GUI. 