### PR TITLE
feat: allow inkscape_silhouette to append to the log/dump files

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -12,6 +12,8 @@
       <param name="cuttingmat" type="enum" _gui-text="Cutting Mat:">
         <item value="cameo_12x12">Cameo 12x12</item>
         <item value="cameo_12x24">Cameo 12x24</item>
+        <item value="cameo_plus_15x15">Cameo Plus 15x15</item>
+        <item value="cameo_pro_24x24">Cameo Pro 24x24</item>
         <item value="no_mat">None</item>
       </param>
       <param name="toolholder" type="enum" _gui-text="Tool Holder:">
@@ -128,6 +130,7 @@ Minimal Traveling (no reverse): Like fully optimized but respect original orient
       <param name="log_paths" type="boolean" _gui-text="Include final cut paths in log (for debugging)">false</param>
       <param name="cmdfile" type="string" _gui-text="Transcribe cutter commands to file:"></param>
       <param name="inc_queries" type="boolean" _gui-text="Include cutter queries in command transcript">false</param>
+      <param name="append_logs" type="boolean" _gui-text="Append to log/dump files rather than overwriting">false</param>
       <param name="dry_run" type="boolean" _gui-text="Dry Run: do not send commands to device">false</param>
       <!-- CAUTION: keep hardware list in sync with silhouette/Graphtec.py -->
       <param name="force_hardware" type="enum" _gui-text="Override cutter model to:">


### PR DESCRIPTION
  (As a selectable option to the previous behavior, of overwriting
  the dump/log if they already existed. This is primarily
  motivated by #156, because it multi operation it makes most
  sense to append to the log and/or command file. However, it can
  also be a standalone change to the basic inkscape_silhouette, so
  I thought I should submit it separately.)

  In testing this, I found there was no way to select the Cameo
  cutting mat that I had loaded in my machine, so I added a couple
  of new mat types.

  That in turn meant I had to find the commands that needed to be
  issued for these mat types. So I indulged in a bit of USB packet
  capture, which I recorded in Commands.md along with a
  comprehensive list of all of the commands that appear to have
  been used/documented to date.

  I recognize this is in some sense a mashup of what might most
  properly be two commits or even PRs: add the mats (and the 
  command docs) on the one hand, and allow log appending on the
  other. I was hoping that it would be OK since they're both pretty
  minor and I got onto the mats in trying to test my change to the
  logs -- it just caught me by surprise that the larger mats were
  not already in the extension. But if the maintainers would like me
  to split this in two, please let me know.

  Finally, whichever of this and #156 is merged first, the other will
  require a tiny bit of manual merging, as they both affect the
  opening of the log file in silhouette_multi.py. I will be happy to
  do that, as soon as one is merged.