### PR TITLE
Install extensions as console_scripts

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,6 +75,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pytest
+    - name: install pkg
+      run: |
+        pip install .
     - name: test
       env:
         PYTHONWARNINGS: default

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+build/
+/inkscape_silhouette.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PREFIX?=/usr
 DISTNAME=inkscape-silhouette
 EXCL=--exclude \*.orig --exclude \*.pyc
 ALL=README.md *.png *.sh *.rules *.py *.inx examples misc silhouette
-VERS=$$(python3 ./sendto_silhouette.py --version)
+VERS=$$(python3 ./silhouette/send.py --version)
 
 ## echo python3 ./sendto_silhouette.py
 # 'module' object has no attribute 'core'
@@ -43,15 +43,13 @@ install:
 
 install-local:
 	mkdir -p $(DESTLOCAL)
-	# CAUTION: cp -a does not work under fakeroot. Use cp -r instead.
-	cp -r silhouette $(DESTLOCAL)
-	install -m 755 -t $(DESTLOCAL) *silhouette*.py
+	pip install .
 	install -m 644 -t $(DESTLOCAL) *.inx
 
 tar_dist_classic: clean
 	name=$(DISTNAME)-$(VERS); echo "$$name"; echo; \
 	tar jcvf $$name.tar.bz2 $(EXCL) --transform="s,^,$$name/," $(ALL)
-	grep about_version ./sendto_silhouette.inx 
+	grep about_version ./sendto_silhouette.inx
 	@echo version should be $(VERS)
 
 tar_dist:

--- a/README.md
+++ b/README.md
@@ -135,8 +135,13 @@ sudo make install   # OR: make install-local  # latter installs only for this us
 #### Silhouette inkscape extension itself
 
 * Download https://github.com/fablabnbg/inkscape-silhouette/archive/master.zip
-* Open the downloaded file and select the following five items: `silhouette`, `sendto_silhouette.inx`, `sendto_silhouette.py`, `silhouette_multi.inx`, `silhouette_multi.py`
-* Extract them to your `share\inkscape\extensions` directory, e.g. `C:\Program Files\Inkscape\share\inkscape\extensions`
+* Open and extract the downloaded archive and install the python pkg using
+  `pip install .`.
+* Make sure that the two executables (`sendto_silhouette` and
+  `silhouette_multi`) are executable.
+* Copy the two inkscape extension files (with the extension `.inx`) into
+  your extensions directory (e.g. `/usr/share/inkscape/extensions/`,
+  `~/.config/inkscape/extensions` or for Windows into `C:\Program Files\Inkscape\share\inkscape\extensions`)
 * Restart inkscape
 
 ## Usage

--- a/distribute/distribute.sh
+++ b/distribute/distribute.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo "Determining Version:"
-VERSION=$(python3 ../sendto_silhouette.py --version)
+VERSION=$(python3 ../silhouette/send.py --version)
 
 test -e /usr/bin/xpath || sudo apt-get install libxml-xpath-perl
 test -e /usr/bin/checkinstall || sudo apt-get install checkinstall

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -4,7 +4,7 @@
   <id>com.github.jnweiger.inskscape-silhouette</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
-  <dependency type="executable" location="extensions">sendto_silhouette.py</dependency>
+  <dependency type="executable" location="path">sendto_silhouette</dependency>
   <param name="active-tab" type="notebook">
     <page name='silhouette' _gui-text='Silhouette'>
       <param name="x_off" type="float" min="-999.0" max="999.0" precision="2" _gui-text="X-Offset [mm]">0.0</param>
@@ -171,7 +171,7 @@ Always use the least amount of blade possible.
     </page>
     <page name='about' _gui-text='About'>
       <param name="about_who" type="description">inkscape-silhouette extension from https://github.com/fablabnbg/inkscape-silhouette by Jürgen Weigert [juergen@fabmail.org] and contributors</param>
-      <!-- Keep in sync with sendto_silhouette.py line 94 __version__ = ... -->
+      <!-- Keep in sync with the version in setup.py -->
       <param name="about_version" type="description">Version 1.25</param>
     </page>
   </param>
@@ -184,6 +184,6 @@ Always use the least amount of blade possible.
   </effect>
 
   <script>
-      <command reldir="extensions" interpreter="python">sendto_silhouette.py</command>
+    <command reldir="path">sendto_silhouette</command>
   </script>
 </inkscape-extension>

--- a/setup.py
+++ b/setup.py
@@ -1,58 +1,25 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-#
-# sudo zypper in python-setuptools
-# http://docs.python.org/2/distutils/setupscript.html#installing-additional-files
-#
-import sys
+import io
 from os import path
-import glob
-import re
 
 from distutils.core import setup
-from setuptools.command.test import test as TestCommand
-import sendto_silhouette  # for author(), version()
 
 # read the contents of your README file
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
-
-e = sendto_silhouette.SendtoSilhouette()
-m = re.match(r'(.*)\s+<(.*)>', e.author())
-
-# print('.',['Makefile']+glob.glob('silhouette-*')),('misc',glob.glob('misc/*'))
-
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 setup(name='inkscape-silhouette',
-      version=e.version(),
+      # keep this in sync with the version in sendto_silhouette.inx and with
+      # the version in silhouette/__init__.py
+      version="1.25",
       description='Inkscape extension for driving a silhouette cameo',
-      author=m.groups()[0],
-      author_email=m.groups()[1],
-      url='https://github.com/jnweiger/inkscape-silhouette',
-      scripts=['sendto_silhouette.py'],
-      #scripts=filter(path.isfile,
-      #               ['sendto_silhouette.py',
-      #                'sendto_silhouette.inx',
-      #                'README.md'] +
-      #               glob.glob('silhouette-*') +
-      #               glob.glob('misc/*') +
-      #               glob.glob('misc/*/*')),
-
+      author="Juergen Weigert",
+      author_mail="juergen@fabmail.org",
+      url='https://github.com/fablabnbg/inkscape-silhouette',
       packages=['silhouette'],
+      entry_points={"console_scripts": ["sendto_silhouette=silhouette.send:main",
+                                        "silhouette_multi=silhouette.multi:main"]},
       license='GPL-2.0',
       classifiers=[
           'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
@@ -61,7 +28,6 @@ setup(name='inkscape-silhouette',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           ],
-      cmdclass={'test': PyTest},
       long_description=long_description,
       long_description_content_type='text/markdown',
       # tests_require=['pytest', 'scipy'],

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,49 @@
-import io
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# sudo zypper in python-setuptools
+# http://docs.python.org/2/distutils/setupscript.html#installing-additional-files
+#
+import sys
 from os import path
+import re
 
 from distutils.core import setup
+from setuptools.command.test import test as TestCommand
+import silhouette  # for author, version
 
 # read the contents of your README file
 this_directory = path.abspath(path.dirname(__file__))
-with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
+
+m = re.match(r'(.*)\s+<(.*)>', silhouette.__author__)
+
+# print('.',['Makefile']+glob.glob('silhouette-*')),('misc',glob.glob('misc/*'))
+
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
 
 
 setup(name='inkscape-silhouette',
-      # keep this in sync with the version in sendto_silhouette.inx and with
-      # the version in silhouette/__init__.py
-      version="1.25",
+      version=silhouette.__version__,
       description='Inkscape extension for driving a silhouette cameo',
-      author="Juergen Weigert",
-      author_mail="juergen@fabmail.org",
-      url='https://github.com/fablabnbg/inkscape-silhouette',
-      packages=['silhouette'],
+      author=m.groups()[0],
+      author_email=m.groups()[1],
+      url='https://github.com/jnweiger/inkscape-silhouette',
       entry_points={"console_scripts": ["sendto_silhouette=silhouette.send:main",
                                         "silhouette_multi=silhouette.multi:main"]},
+      packages=['silhouette'],
       license='GPL-2.0',
       classifiers=[
           'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
@@ -28,6 +52,7 @@ setup(name='inkscape-silhouette',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           ],
+      cmdclass={'test': PyTest},
       long_description=long_description,
       long_description_content_type='text/markdown',
       # tests_require=['pytest', 'scipy'],

--- a/silhouette/__init__.py
+++ b/silhouette/__init__.py
@@ -1,3 +1,4 @@
 # __init__ is needed for import statements across subdirectories.
 
 __version__ = "1.25"
+__author__ = "Juergen Weigert <juergen@fabmail.org> and contributors"

--- a/silhouette/__init__.py
+++ b/silhouette/__init__.py
@@ -1,1 +1,3 @@
 # __init__ is needed for import statements across subdirectories.
+
+__version__ = "1.25"

--- a/silhouette/multi.py
+++ b/silhouette/multi.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import sys
 import time
@@ -666,7 +664,7 @@ class SilhouetteMulti(inkex.Effect):
 
         self.saved_argv = list(sys.argv)
 
-        # Patch methods as in sendto_silhouette.py
+        # Patch methods as in send.py
         # for inkscape 0.9x compatibility:
         if not hasattr(self, "run"): self.run = self.affect
         if not hasattr(self, "arg_parser"):
@@ -799,8 +797,7 @@ class SilhouetteMulti(inkex.Effect):
         commands = []
 
         for color, settings in actions:
-            command = sys.executable
-            command += " sendto_silhouette.py"
+            command = "sendto_silhouette"
             command += " " + self.format_args(settings)
             command += " " + self.id_args(self.objects_by_color[color])
             command += " " + self.svg_copy_file_name
@@ -876,8 +873,7 @@ class SilhouetteMulti(inkex.Effect):
     # end of class MyFrame
 
 
-if __name__ == "__main__":
-
+def main():
     unblock_inkscape = True
     if '--block=true' in sys.argv:
         unblock_inkscape = False
@@ -914,5 +910,3 @@ if __name__ == "__main__":
         # an exception, so:
         if unblock_inkscape:
             show_log_as_dialog()
-
-    sys.exit(0)

--- a/silhouette/send.py
+++ b/silhouette/send.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Inkscape extension for driving a silhouette cameo
 # (C) 2013 jw@suse.de. Licensed under CC-BY-SA-3.0 or GPL-2.0 at your choice.
 # (C) 2014, 2015 juewei@fabmail.org
@@ -91,16 +89,7 @@
 
 from __future__ import print_function
 
-__version__ = "1.25"     # Keep in sync with sendto_silhouette.inx ca line 79
-__author__ = "Juergen Weigert <juergen@fabmail.org> and contributors"
-
 import sys, os, time, tempfile, math, operator, re
-
-
-# we sys.path.append() the directory where this
-# sendto_silhouette.py script lives. Attempt to help with
-# https://github.com/jnweiger/inkscape-silhouette/issues/3
-sys.path.append(os.path.dirname(os.path.abspath(sys.argv[0])))
 
 sys_platform = sys.platform.lower()
 if sys_platform.startswith("win"):
@@ -126,6 +115,7 @@ if not sys.stdout:
     sys.stdout=os.fdopen(os.open(os.devnull, os.O_WRONLY|os.O_APPEND), 'w')
     dummy_stdout=True
 
+from silhouette import __version__
 import inkex
 
 if dummy_stdout:
@@ -404,7 +394,7 @@ class SendtoSilhouette(inkex.Effect):
                 help="show cut pattern graphically before sending")
         self.arg_parser.add_argument("-V", "--version",
                 dest = "version", action = "store_true",
-                help="Just print version number ('"+self.version()+"') and exit.")
+                help="Just print version number and exit.")
         self.arg_parser.add_argument("-w", "--wait", "--wait-done", "--wait_done",
                 dest = "wait_done", type = inkex.Boolean, default = False,
                 help="After sending wait til device reports ready")
@@ -452,15 +442,6 @@ class SendtoSilhouette(inkex.Effect):
     def __del__(self, *args):
         if self.log:
             self.log.close() # will always close tty if there is one
-
-
-    def version(self):
-        return __version__
-
-
-    def author(self):
-        return __author__
-
 
     def report(self, message, level):
         """ Display `message` to the appropriate output stream(s).
@@ -1423,7 +1404,7 @@ Each of the following `level` values encompasses all of the later ones:
         self.report("\nstatus=%s" % (state), 'log')
 
 
-if __name__ == "__main__":
+def main():
     e = SendtoSilhouette()
 
     if any((len(sys.argv) < 2, "--version" in sys.argv, "-V" in sys.argv)):
@@ -1442,4 +1423,7 @@ if __name__ == "__main__":
         ss -= mm*60
         e.report(" done. %d min %d sec" % (mm, ss), 'log')
 
-    sys.exit(0)
+
+if __name__ == '__main__':
+    # only needed for the build system
+    main()

--- a/silhouette_multi.inx
+++ b/silhouette_multi.inx
@@ -4,7 +4,7 @@
   <id>com.github.jnweiger.inskscape-silhouette-multi</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
-  <dependency type="executable" location="extensions">silhouette_multi.py</dependency>
+  <dependency type="executable" location="path">silhouette_multi</dependency>
 
   <param name="multi_help" type="description" xml:space="preserve">
 Debugging/Logging Settings:
@@ -21,8 +21,8 @@ Cutting settings will show up once you click "Apply."
       <submenu _name="Export"/>
     </effects-menu>
   </effect>
-  
+
   <script>
-      <command reldir="extensions" interpreter="python">silhouette_multi.py</command>
+    <command reldir="path">silhouette_multi</command>
   </script>
 </inkscape-extension>

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -10,7 +10,7 @@ class TestRun(unittest.TestCase):
 
     def test_00import_inkex(self):
         try:
-            result = subprocess.check_output([sys.executable, "-c", "import sendto_silhouette;import inkex;print(inkex)"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output([sys.executable, "-c", "import silhouette.send;import inkex;print(inkex)"], stderr=subprocess.STDOUT)
             #print(result.decode())
         except subprocess.CalledProcessError as e:
             print(e.output.decode())
@@ -21,9 +21,9 @@ class TestRun(unittest.TestCase):
 
     def test_01help(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--help"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["sendto_silhouette", "--help"], stderr=subprocess.STDOUT)
             #print(result.decode())
-            self.assertIn('sage: sendto_silhouette.py', str(result))
+            self.assertIn('sage: sendto_silhouette', str(result))
             self.assertIn('--help', str(result))
         except subprocess.CalledProcessError as e:
             print(e.output.decode())
@@ -34,7 +34,7 @@ class TestRun(unittest.TestCase):
 
     def test_02version(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--version"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["sendto_silhouette", "--version"], stderr=subprocess.STDOUT)
             #print(result.decode())
             self.assertIn('1.', str(result))
         except subprocess.CalledProcessError as e:
@@ -46,7 +46,7 @@ class TestRun(unittest.TestCase):
 
     def test_03run(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["sendto_silhouette"], stderr=subprocess.STDOUT)
             print(result.decode())
         except subprocess.CalledProcessError as e:
             print(e.output.decode())
@@ -57,7 +57,7 @@ class TestRun(unittest.TestCase):
 
     def test_04dry_run(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dry_run=True", "--preview=False", "--log_paths=True", "--logfile=silhouette.log", "examples/testcut_square_triangle.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["sendto_silhouette", "--dry_run=True", "--preview=False", "--log_paths=True", "--logfile=silhouette.log", "examples/testcut_square_triangle.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
             filehandle = open("silhouette.log",'r')
             log = filehandle.read()
@@ -72,7 +72,7 @@ class TestRun(unittest.TestCase):
 
     def test_05dry_run(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dry_run=True", "--preview=False", "--log_paths=True", "--logfile=silhouette.log", "examples/testcut_square_triangle_o.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["sendto_silhouette", "--dry_run=True", "--preview=False", "--log_paths=True", "--logfile=silhouette.log", "examples/testcut_square_triangle_o.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
             filehandle = open("silhouette.log",'r')
             log = filehandle.read()
@@ -87,7 +87,7 @@ class TestRun(unittest.TestCase):
 
     def test_06dry_run(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dry_run=True", "--preview=False", "--log_paths=True", "--logfile=silhouette.log", "examples/sharp_turns.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["sendto_silhouette", "--dry_run=True", "--preview=False", "--log_paths=True", "--logfile=silhouette.log", "examples/sharp_turns.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
             filehandle = open("silhouette.log",'r')
             log = filehandle.read()
@@ -102,7 +102,7 @@ class TestRun(unittest.TestCase):
 
     def test_07dry_run(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dashes=True", "--preview=False", "--dry_run=True", "--log_paths=True", "--logfile=silhouette.log", "examples/dashline.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["sendto_silhouette", "--dashes=True", "--preview=False", "--dry_run=True", "--log_paths=True", "--logfile=silhouette.log", "examples/dashline.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
             filehandle = open("silhouette.log",'r')
             log = filehandle.read()
@@ -116,7 +116,7 @@ class TestRun(unittest.TestCase):
 
     def test_08cmd_file(self):
         try:
-            result = subprocess.check_output([sys.executable, "sendto_silhouette.py", "--dry_run=True", "--preview=False", "--cmdfile=testcut_square_triangle_o.cmd", "--force_hardware=Silhouette SD 1", "examples/testcut_square_triangle_o.svg"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["sendto_silhouette", "--dry_run=True", "--preview=False", "--cmdfile=testcut_square_triangle_o.cmd", "--force_hardware=Silhouette SD 1", "examples/testcut_square_triangle_o.svg"], stderr=subprocess.STDOUT)
             print(result.decode())
             filehandle = open("examples/testcut_square_triangle_o.cmd",'r')
             cmdref = filehandle.read()

--- a/test/test_umockdev.py
+++ b/test/test_umockdev.py
@@ -3,7 +3,6 @@
 import pytest
 import unittest
 import subprocess
-import sys
 import platform
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="only runs on Linux")
@@ -11,7 +10,7 @@ class TestUmockdev(unittest.TestCase):
 
     def test_run_cameo3(self):
         try:
-            result = subprocess.check_output(["umockdev-run", "--device=test/umockdev/cameo3.umockdev", "--ioctl=/dev/bus/usb/003/017=test/umockdev/cameo3.ioctl", sys.executable, "sendto_silhouette.py"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["umockdev-run", "--device=test/umockdev/cameo3.umockdev", "--ioctl=/dev/bus/usb/003/017=test/umockdev/cameo3.ioctl", "sendto_silhouette"], stderr=subprocess.STDOUT)
             print(result.decode())
             return result
         except subprocess.CalledProcessError as e:

--- a/test/umockdev/run.sh
+++ b/test/umockdev/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-umockdev-run --device=/tmp/cameo3.umockdev --ioctl=/dev/bus/usb/003/017=/tmp/cameo3.ioctl python sendto_silhouette.py
+umockdev-run --device=/tmp/cameo3.umockdev --ioctl=/dev/bus/usb/003/017=/tmp/cameo3.ioctl sendto_silhouette


### PR DESCRIPTION
Since a `setup.py` file exists in the src tree, it should also be used for the installation, which is currently not the case if one follows the instructions in the README. The README says that the requires files should be copied into the inkscape `extensions` directory. IMO the files in the `silhouette` directory should be properly installed and executables of the two extensions should be created, which should be used in the `inx` files.

This is done in this PR. Furthermore the pytest related code from setup.py was removed, because
the `test` subcommand of `setup.py` is deprecated.