### PR TITLE
Fix a crash in wait_for_ready when state is "unloaded"

### DIFF
--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -733,7 +733,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
       if verbose: print(" %d/%d: status=%s\r" % (i, npolls, state), end='', file=sys.stderr)
       if verbose == False:
         if state == 'unloaded':
-          print(" %d/%d: please load media ...\r" % (i, npolls, state), end='', file=sys.stderr)
+          print(" %d/%d: please load media ...\r" % (i, npolls), end='', file=sys.stderr)
         elif i > npolls/3:
           print(" %d/%d: status=%s\r" % (i, npolls, state), end='', file=sys.stderr)
       time.sleep(poll_interval)


### PR DESCRIPTION
This is basically a typo fix, there were more arguments provided to string formatting than arguments used in the string.