### PR TITLE
Add description for BEn, FA, and Firmware upgrade to Commands.md

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -95,7 +95,9 @@ A                                    Alpha Reset            (G)  Returns the par
 					                    to the values set at the initialization of the plotter
 Bl,                                  Line Scale             (G)  Specifies the pitch of broken lines (needed if
                                                             non-0 line type is used)
-BEn                                                         Observed in Cameo 4 Pro capture
+BEn                                                         Binary encoded Relative Draw, n says how many bytes to read (1-3).
+                                                            Observed on Cameo 4 Pro and Portrait 3.
+                                                            For coordinate encoding see beutil.py
 BS sa,sb,sc,sd                       Buffer Size            (G)  Marked as a no-op
 BZ a,xa,ya,xb,yb,xc,yc,xd,yd[,d]     Bezier Curve           (G)[t]  Not clear what a or [,d] mean
 C                                    Call GIN               (G)  In "Output Coordinates" section, puts the
@@ -109,11 +111,10 @@ Exa,ya,xb,yb,...,xn,yn               Relative Draw          (G)[t]  Coordinates 
                                                             by xa,ya, or from the position at the commencement of the command
 EPr,t                                Relative Draw Polar    (G)[t]
 Fl                                   Chart Feed             (G)[t]  ??
-FA                                   Calibration Query      Exact semantics/responses unclear; see
-                                                            silhouette/graphtec.py
+FA                                   Calibration Query      Returns values set with FBrc,rr.
 FBrc,rr                              Set Motion Scaling     rc and rr scale carriage and roller movements by
                                                             basis points (see examples below); used only for calibration, as
-					                    effects are permanent
+                                                            effects are permanent.
 FCp,q[,n]                            Cutter Offset          (G)[t]  Not clear what p,q mean, but Silhouette
                                                             Studio definitely emits this command, see below for some apparent
                                                             p-values; silhouette/Graphtec.py says p and q are millimeter

--- a/Commands.md
+++ b/Commands.md
@@ -494,3 +494,9 @@ L0 \0,0 M0,0 J0 FN0 TB50,0
 with Cameo Plus 15x15 mat, all was the same except the 7th line was replaced with:
 
 TG8 FN0 TB50,0 FM1 \30,9 Z7590,7320
+
+Portrait 3 Firmware Upgrade
+---------------------------
+Upgrading the firmware is a stream of `S{address}{data}\n`, with no 0x03 in sight.
+There is no initialisation protocol, the Portrait3_V104_R0001.S that comes with Silhouette Studio is streamed as is.
+This was observed when upgrading from V1.01 to V1.04.


### PR DESCRIPTION
`BEn` is already described in Commands.md and `beutil.py`. I've checked with a simple cut, and the decoding for BE1 and BE2 was correct.

`FA` I've tested myself.

Firmware Upgrade was a missclick that fortunately got recorded with Wireshark :-) It's just sending a .S file from Silhouette Studio installation.