### PR TITLE
Fix handling of duplicates

### DIFF
--- a/test/data/plus_with_duplicate.svg
+++ b/test/data/plus_with_duplicate.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="plus_with_duplicate.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="3.6233469"
+     inkscape:cx="69.134976"
+     inkscape:cy="99.493648"
+     inkscape:window-width="1570"
+     inkscape:window-height="970"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Warstwa 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 10,0 V 20 M 0,10 h 20"
+       id="path857"
+       sodipodi:nodetypes="cccc" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#path857"
+       id="use1652"
+       transform="translate(20,20)"
+       width="100%"
+       height="100%"
+       style="stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/test/test_sendto_silhouette.py
+++ b/test/test_sendto_silhouette.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from sendto_silhouette import SendtoSilhouette
+
+
+@pytest.fixture
+def data_dir():
+    return Path(__file__).parent / 'data'
+
+
+def test_loading_duplicated_path(data_dir):
+    effect = SendtoSilhouette()
+    effect.parse_arguments([str(data_dir / 'plus_with_duplicate.svg')])
+    effect.load_raw()
+    effect.recursivelyTraverseSvg(effect.document.getroot())
+
+    assert effect.paths == [
+        # First cross
+        [(10.0, 0.0), (10.0, 20.0)],
+        [(0.0, 10), (20.0, 10)],
+        # Second cross, the duplicate
+        [(30.0, 20.0), (30.0, 40.0)],
+        [(20.0, 30), (40.0, 30)],
+    ]


### PR DESCRIPTION
Duplicated nodes had the document transform applied twice, once in the inherited extra_transform and then again at the top of recursivelyTraverseSvg.