### PR TITLE
feat(multi): Show the return code in case command fails

### DIFF
--- a/silhouette_multi.py
+++ b/silhouette_multi.py
@@ -862,14 +862,15 @@ class SilhouetteMulti(inkex.Effect):
 
     def run_commands_with_dialog(self, commands):
         for i, command in enumerate(commands):
-            if not self.run_command_with_dialog(command, step=i + 1, total=len(commands)):
+            returncode = self.run_command_with_dialog(command, step=i + 1, total=len(commands))
+            if returncode != 0:
                 # At this point, we have already displayed the log if we are
                 # going to. So if we want the user to see the failed command
                 # we just have to go ahead and display it.
                 # But we will use the dialog's extended message to reduce
                 # visual clutter
                 info_dialog(None, "Action failed.",
-                            extended = "Command: '" + command + "'")
+                            extended = f"Return code: {returncode}\nCommand: '{command}'")
 
                 sys.exit(1)
 
@@ -907,7 +908,7 @@ class SilhouetteMulti(inkex.Effect):
 
         dialog.Destroy()
         wx.Yield()
-        return process.returncode == 0
+        return process.returncode
 
     # end of class MyFrame
 


### PR DESCRIPTION
This is just a revival of #188 now that silhouette_multi is working again in main. (I couldn't reopen the original PR because github won't let you do that after a force push.) As this change was critical in diagnosing #172 I am hoping it can be considered for merging, thanks. (And once this PR is resolved either way, I will file a PR to fix #172.)