### PR TITLE
fix(multi): Remove whitespace from hardware device names

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -134,18 +134,18 @@ Minimal Traveling (no reverse): Like fully optimized but respect original orient
       <!-- CAUTION: keep hardware list in sync with silhouette/Graphtec.py -->
       <param name="force_hardware" type="enum" _gui-text="Override cutter model to:">
 	<item value="DETECT">-- as detected --</item>
-	<item value="Silhouette Portrait">Silhouette Portrait</item>
-	<item value="Silhouette Portrait2">Silhouette Portrait 2</item>
-	<item value="Silhouette Portrait3">Silhouette Portrait 3</item>
-	<item value="Silhouette Cameo">Silhouette Cameo</item>
-	<item value="Silhouette Cameo2">Silhouette Cameo 2</item>
-	<item value="Silhouette Cameo3">Silhouette Cameo 3</item>
-	<item value="Silhouette Cameo4">Silhouette Cameo 4</item>
-	<item value="Silhouette Cameo4 Pro">Silhouette Cameo 4 Pro</item>
-	<item value="Craft Robo CC200-20">Craft Robo CC200-20</item>
-	<item value="Craft Robo CC300-20">Craft Robo CC300-20</item>
-	<item value="Silhouette SD 1">Silhouette SD 1</item>
-	<item value="Silhouette SD 2">Silhouette SD 2</item>
+	<item value="Silhouette_Portrait">Silhouette Portrait</item>
+	<item value="Silhouette_Portrait2">Silhouette Portrait 2</item>
+	<item value="Silhouette_Portrait3">Silhouette Portrait 3</item>
+	<item value="Silhouette_Cameo">Silhouette Cameo</item>
+	<item value="Silhouette_Cameo2">Silhouette Cameo 2</item>
+	<item value="Silhouette_Cameo3">Silhouette Cameo 3</item>
+	<item value="Silhouette_Cameo4">Silhouette Cameo 4</item>
+	<item value="Silhouette_Cameo4_Pro">Silhouette Cameo 4 Pro</item>
+	<item value="Craft_Robo_CC200-20">Craft Robo CC200-20</item>
+	<item value="Craft_Robo_CC300-20">Craft Robo CC300-20</item>
+	<item value="Silhouette_SD_1">Silhouette SD 1</item>
+	<item value="Silhouette_SD_2">Silhouette SD 2</item>
       </param>
       <label>Using any setting other than `as detected' is not recommended except when performing a dry run.</label>
     </page>

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -185,39 +185,39 @@ SILHOUETTE_CAMEO4_TOOL_ERROR = 255
 
 DEVICE = [
  # CAUTION: keep in sync with sendto_silhouette.inx
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT, 'name': 'Silhouette Portrait',
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT, 'name': 'Silhouette_Portrait',
    'width_mm':  206, 'length_mm': 3000, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT2, 'name': 'Silhouette Portrait2',
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT2, 'name': 'Silhouette_Portrait2',
    'width_mm':  203, 'length_mm': 3000, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT3, 'name': 'Silhouette Portrait3',
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT3, 'name': 'Silhouette_Portrait3',
    'width_mm':  203, 'length_mm': 18290, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO, 'name': 'Silhouette Cameo',
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO, 'name': 'Silhouette_Cameo',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!
    'width_mm':  304, 'length_mm': 3000, 'margin_left_mm':9.0, 'margin_top_mm':1.0, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO2, 'name': 'Silhouette Cameo2',
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO2, 'name': 'Silhouette_Cameo2',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!
    'width_mm':  304, 'length_mm': 3000, 'margin_left_mm':9.0, 'margin_top_mm':1.0, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO3, 'name': 'Silhouette Cameo3',
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO3, 'name': 'Silhouette_Cameo3',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!
    'width_mm':  304.8, 'length_mm': 3000, 'margin_left_mm':0.0, 'margin_top_mm':0.0, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO4, 'name': 'Silhouette Cameo4',
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO4, 'name': 'Silhouette_Cameo4',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!
    'width_mm':  304.8, 'length_mm': 3000, 'margin_left_mm':0.0, 'margin_top_mm':0.0, 'regmark': True },
 #### Uncomment when confirmed:
 # { 'vendor_id': VENDOR_ID_GRAPHTEC,
 #   'product_id': VENDOR_ID_SILHOUETTE_CAMEO4PLUS,
-#   'name': 'Silhouette Cameo4 Plus',
+#   'name': 'Silhouette_Cameo4_Plus',
 #   'width_mm': 372, # A bit of a guess, not certain what actual cuttable is
 #   'length_mm': 3000,
 #   'margin_left_mm': 0.0, 'margin_top_mm': 0.0, 'regmark': True },
 ##############################
  { 'vendor_id': VENDOR_ID_GRAPHTEC,
    'product_id': PRODUCT_ID_SILHOUETTE_CAMEO4PRO,
-   'name': 'Silhouette Cameo4 Pro',
+   'name': 'Silhouette_Cameo4_Pro',
    'width_mm': 600, # 24 in. is 609.6mm, but Silhouette Studio shows a thin cut
                     # margin that leaves 600mm of cuttable width. However,
                     # I am not certain if this should be margin_left_mm = 4.8
@@ -225,11 +225,11 @@ DEVICE = [
                     # the prior Cameo4 settings above.
    'length_mm': 3000,
    'margin_left_mm': 0.0, 'margin_top_mm': 0.0, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_CC200_20, 'name': 'Craft Robo CC200-20',
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_CC200_20, 'name': 'Craft_Robo_CC200-20',
    'width_mm':  200, 'length_mm': 1000, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_CC300_20, 'name': 'Craft Robo CC300-20' },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_SD_1, 'name': 'Silhouette SD 1' },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_SD_2, 'name': 'Silhouette SD 2' },
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_CC300_20, 'name': 'Craft_Robo_CC300-20' },
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_SD_1, 'name': 'Silhouette_SD_1' },
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_SD_2, 'name': 'Silhouette_SD_2' },
 ]
 
 


### PR DESCRIPTION
  When silhouette_multi calls sendto_silhouette, if the force_hardware parameter
  has been set, it places the name of the device being forced on the command
  line. If that name contains any whitespace, the command-line parsing of
  sendto_silhouette fails. This commit resolves the situation by replacing
  all whitespace in device names with underscores.

  Resolves #172.

(I promise the next thing I will work on after this is at least some sort of test for silhouette_multi.)