### PR TITLE
Prevent running if preview requested & matplotlib not installed

### DIFF
--- a/silhouette/read_dump.py
+++ b/silhouette/read_dump.py
@@ -38,10 +38,10 @@ def plotcuts(cuts, buttons=False):
     if plt is None:
         print("Install matplotlib for python to allow graphical display of cuts",
               file=sys.stderr)
-        return False
+        return True
     if cuts == []:
         print("Empty path", file=sys.stderr)
-        return False
+        return True
     xy = sum(cuts, [])
     least = min(min(p[0],p[1]) for p in xy)
     greatest = max(max(p[0],p[1]) for p in xy)


### PR DESCRIPTION
The machine started running directly, even when preview was requested, because matplotlib was not installed yet.
Simple fix, now the preview function returns True (cancel job) in that case.