### PR TITLE
render_silhouette_regmarks: render rego mark (From miLORD1337)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,21 @@ This fails on win32/64 with 'module has no attribute 'version info' which then c
 ## Using of registration marks
 
 The plotter will search the registration marks at the given positions.
-If it founds the marks, they will serve as accurate reference and define the origin.
+If it locates the marks, they will serve as accurate reference and define the origin.
 Therefore it is necessary to set the correct offset values of the mark.
 As a result the cut will go precisely along the graphics.
 
+### Applying registration marks
 
-To plot with registration marks do the following:
+You have the option of using the provided template at `examples/registration-marks-cameo-silhouette-a4-maxi.svg` for Silhouette Cameo using A4 paper format.
+
+On the other hand for more custom setups you can use this instead.
+
+1. Go to Extensions -> Render -> Silhouette Regmarks -> Classic...
+2. Edit position and size of registration marks to your liking
+3. Apply
+
+### Plot with registration marks steps
 
 1. Open the document which fit to your setup, e.g. `examples/registration-marks-cameo-silhouette-a4-maxi.svg` for Silhouette Cameo using A4 paper format.
 2. Insert your cutting paths and graphics on the apropriate layers.

--- a/render_silhouette_regmarks.inx
+++ b/render_silhouette_regmarks.inx
@@ -6,8 +6,8 @@
   <param name="regoriginx" type="float" min="10.0" max="10000" gui-text="Position of regmark from document left [mm]">10</param>
   <param name="regoriginy" type="float" min="10.0" max="10000" gui-text="Position of regmark from document top [mm]">10</param>
   <param indent="2">Spacing of the registration mark edges</param>
-  <param name="regwidth" type="float" min="0.0" max="10000" gui-text="X mark distance [mm]"></param>
-  <param name="reglength" type="float" min="0.0" max="10000" gui-text="Y mark distance [mm]"></param>
+  <param name="regwidth" type="float" min="0.0" max="10000" gui-text="X mark to mark distance [mm]"></param>
+  <param name="reglength" type="float" min="0.0" max="10000" gui-text="Y mark to mark distance [mm]"></param>
   <param indent="2">Distance between registration mark edges</param>
   <label indent="2">Note: If width and length spacing is empty, then it is calculated from current document size.</label>
   <param name="verbose" type="bool" gui-text="display verbose log messages">false</param>

--- a/render_silhouette_regmarks.inx
+++ b/render_silhouette_regmarks.inx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <_name>Classic</_name>
+  <id>org.inkscape.render.silhouette-regmarks</id>
+  <!--<dependency type="executable" location="extensions">inkex.py</dependency>-->
+  <dependency type="executable" location="extensions">render_silhouette_regmarks.py</dependency>
+  <param name="regoriginx" type="float" min="10.0" max="10000" _gui-text="Position of regmark from document left [mm]">10</param>
+  <param name="regoriginy" type="float" min="10.0" max="10000" _gui-text="Position of regmark from document top [mm]">10</param>
+  <param indent="2" name="regdistance_help" type="description">Spacing of the registration mark edges</param>
+  <param name="regwidth" type="float" min="0.0" max="10000" _gui-text="X mark distance [mm]"></param>
+  <param name="reglength" type="float" min="0.0" max="10000" _gui-text="Y mark distance [mm]"></param>
+  <param indent="2" name="regdistance_help" type="description">Distance between registration mark edges</param>
+  <label indent="2">Note: If width and length spacing is empty, then it is calculated from current document size.</label>
+  <effect>
+    <object-type>all</object-type>
+    <effects-menu>
+     <submenu _name="Render">
+        <submenu _name="Silhouette Regmarks" />
+      </submenu>
+    </effects-menu>
+  </effect>
+  <script>
+    <command reldir="extensions" interpreter="python">render_silhouette_regmarks.py</command>
+  </script>
+</inkscape-extension>

--- a/render_silhouette_regmarks.inx
+++ b/render_silhouette_regmarks.inx
@@ -1,26 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Classic</_name>
-  <id>org.inkscape.render.silhouette-regmarks</id>
-  <!--<dependency type="executable" location="extensions">inkex.py</dependency>-->
-  <dependency type="executable" location="extensions">render_silhouette_regmarks.py</dependency>
-  <param name="regoriginx" type="float" min="10.0" max="10000" _gui-text="Position of regmark from document left [mm]">10</param>
-  <param name="regoriginy" type="float" min="10.0" max="10000" _gui-text="Position of regmark from document top [mm]">10</param>
-  <param indent="2" name="regdistance_help" type="description">Spacing of the registration mark edges</param>
-  <param name="regwidth" type="float" min="0.0" max="10000" _gui-text="X mark distance [mm]"></param>
-  <param name="reglength" type="float" min="0.0" max="10000" _gui-text="Y mark distance [mm]"></param>
-  <param indent="2" name="regdistance_help" type="description">Distance between registration mark edges</param>
+<inkscape-extension translationdomain="inkscape-silhouette" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <name>Silhouette Regmarks</name>
+  <id>com.github.fablabnbg.inkscape-silhouette.silhouette-regmarks</id>
+  <dependency type="executable" location="inx">render_silhouette_regmarks.py</dependency>
+  <param name="regoriginx" type="float" min="10.0" max="10000" gui-text="Position of regmark from document left [mm]">10</param>
+  <param name="regoriginy" type="float" min="10.0" max="10000" gui-text="Position of regmark from document top [mm]">10</param>
+  <param indent="2">Spacing of the registration mark edges</param>
+  <param name="regwidth" type="float" min="0.0" max="10000" gui-text="X mark distance [mm]"></param>
+  <param name="reglength" type="float" min="0.0" max="10000" gui-text="Y mark distance [mm]"></param>
+  <param indent="2">Distance between registration mark edges</param>
   <label indent="2">Note: If width and length spacing is empty, then it is calculated from current document size.</label>
   <param name="verbose" type="bool" gui-text="display verbose log messages">false</param>
   <effect>
     <object-type>all</object-type>
     <effects-menu>
-     <submenu _name="Render">
-        <submenu _name="Silhouette Regmarks" />
-      </submenu>
+     <submenu name="Render"/>
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">render_silhouette_regmarks.py</command>
+    <command location="inx" interpreter="python">render_silhouette_regmarks.py</command>
   </script>
 </inkscape-extension>

--- a/render_silhouette_regmarks.inx
+++ b/render_silhouette_regmarks.inx
@@ -11,6 +11,7 @@
   <param name="reglength" type="float" min="0.0" max="10000" _gui-text="Y mark distance [mm]"></param>
   <param indent="2" name="regdistance_help" type="description">Distance between registration mark edges</param>
   <label indent="2">Note: If width and length spacing is empty, then it is calculated from current document size.</label>
+  <param name="verbose" type="bool" gui-text="display verbose log messages">false</param>
   <effect>
     <object-type>all</object-type>
     <effects-menu>

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -23,8 +23,6 @@ import inkex
 from lxml import etree
 from gettext import gettext
 
-SVG_URI = u'http://www.w3.org/2000/svg'
-
 class InsertRegmark(inkex.Effect):
 	def __init__(self):
 		inkex.Effect.__init__(self)
@@ -102,7 +100,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(self.drawRect((REG_SQUARE_MM,REG_SQUARE_MM), (reg_origin_X,reg_origin_Y), 'TopLeft'))
 		
 		# Create group for top right corner
-		topRight = etree.Element('{%s}g' % SVG_URI)
+		topRight = inkex.Group()
 		topRight.set('id', 'TopRight')
 		topRight.set('style', 'fill: black;')
 		
@@ -113,7 +111,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topRight)
 		
 		# Create group for top right corner
-		bottomLeft = etree.Element('{%s}g' % SVG_URI)
+		bottomLeft = inkex.Group()
 		bottomLeft.set('id', 'BottomLeft')
 		bottomLeft.set('style', 'fill: black;')
 		
@@ -126,7 +124,7 @@ class InsertRegmark(inkex.Effect):
 		# Keepout Marker #
 
 		# Create group for top left corner keepout
-		topLeftKeepout = etree.Element('{%s}g' % SVG_URI)
+		topLeftKeepout = inkex.Group()
 		topLeftKeepout.set('id', 'TopLeftKeepout')
 		topLeftKeepout.set('style', 'fill: black;')
 
@@ -138,7 +136,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topLeftKeepout)
 
 		# Create group for top right corner keepout
-		topRightKeepout = etree.Element('{%s}g' % SVG_URI)
+		topRightKeepout = inkex.Group()
 		topRightKeepout.set('id', 'TopRightKeepout')
 		topRightKeepout.set('style', 'fill: black;')
 
@@ -150,7 +148,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topRightKeepout)
 
 		# Create group for bottom right corner keepout
-		bottomRightKeepout = etree.Element('{%s}g' % SVG_URI)
+		bottomRightKeepout = inkex.Group()
 		bottomRightKeepout.set('id', 'BottomRightKeepout')
 		bottomRightKeepout.set('style', 'fill: black;')
 

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -29,6 +29,7 @@ REGMARK_TOP_LEFT_ID = 'regmark-tl'
 REGMARK_TOP_RIGHT_ID = 'regmark-tr'
 REGMARK_BOTTOM_LEFT_ID = 'regmark-bl'
 REGMARK_SAFE_AREA_ID = 'regmark-safe-area'
+REGMARK_NOTES_ID = 'regmark-notes'
 
 REG_SQUARE_MM = 5
 REG_LINE_MM = 20
@@ -122,7 +123,7 @@ class InsertRegmark(EffectExtension):
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		regmark_layer.append(TextElement(safe_area_note, x=f"{(bottom_left_safearea_origin_x+3)}", y=f"{(bottom_left_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = 'RegMarkNotes', style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PT}px"))
+		regmark_layer.append(TextElement(safe_area_note, x=f"{(bottom_left_safearea_origin_x+3)}", y=f"{(bottom_left_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = REGMARK_NOTES_ID, style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PT}px"))
 
 		# Lock Layer
 		regmark_layer.set_sensitive(False)

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -29,17 +29,14 @@ class InsertRegmark(inkex.Effect):
 		
 		# Layer name static, since self.document.getroot() not available on initialization
 		self.layername = 'Regmarks'
-		
+
+	def add_arguments(self, pars):
 		# Parse arguments
-		self.arg_parser.add_argument("-X", "--reg-x", "--regwidth", 
-				type = float, dest = "regwidth", default = 180.0, help="X mark distance [mm]")
-		self.arg_parser.add_argument("-Y", "--reg-y", "--reglength", 
-				type = float, dest = "reglength", default = 230.0, help="Y mark distance [mm]")
-		self.arg_parser.add_argument("--rego-x",  "--regoriginx", 
-				type = float, dest = "regoriginx", default = 15.0, help="X mark origin from left [mm]")
-		self.arg_parser.add_argument("--rego-y", "--regoriginy", 
-				type = float, dest = "regoriginy", default = 20.0, help="X mark origin from top [mm]")
-		self.arg_parser.add_argument("--verbose", dest = "verbose", type = inkex.Boolean, default = False, help="enable log messages")
+		pars.add_argument("-X", "--reg-x", "--regwidth",  type = float, dest = "regwidth",   default = 180.0, help="X mark distance [mm]")
+		pars.add_argument("-Y", "--reg-y", "--reglength", type = float, dest = "reglength",  default = 230.0, help="Y mark distance [mm]")
+		pars.add_argument("--rego-x",  "--regoriginx",    type = float, dest = "regoriginx", default = 15.0,  help="X mark origin from left [mm]")
+		pars.add_argument("--rego-y", "--regoriginy",     type = float, dest = "regoriginy", default = 20.0,  help="X mark origin from top [mm]")
+		pars.add_argument("--verbose", dest = "verbose",  type = inkex.Boolean, default = False, help="enable log messages")
 
 	#SVG rect element generation routine
 	def drawRect(self, size, pos, name):

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -42,12 +42,7 @@ class InsertRegmark(inkex.Effect):
 	def drawRect(self, size, pos, name):
 		x, y = [pos * self.svg.unittouu('1mm') for pos in pos  ]
 		w, h = [pos * self.svg.unittouu('1mm') for pos in size ]
-		rect = inkex.Rectangle()
-		rect.set('x', str(x))
-		rect.set('y', str(y))
-		rect.set('id', name)
-		rect.set('width', str(w))
-		rect.set('height', str(h))
+		rect = inkex.Rectangle.new(x, y, w, h, id=name)
 		rect.set('style', 'fill: black;')
 		return rect
 		
@@ -55,17 +50,12 @@ class InsertRegmark(inkex.Effect):
 	def drawLine(self, posStart, posEnd, name):
 		x1, y1, = [pos * self.svg.unittouu('1mm') for pos in posStart]
 		x2, y2, = [pos * self.svg.unittouu('1mm') for pos in posEnd  ]
-		line = inkex.Line()
-		line.set('x1', str(x1))
-		line.set('y1', str(y1))
-		line.set('x2', str(x2))
-		line.set('y2', str(y2))
-		line.set('id', name)
+		line = inkex.Line.new((x1, y1), (x2, y2), id=name)
 		# https://www.reddit.com/r/silhouettecutters/comments/wcdnzy/the_key_to_print_and_cut_success_an_extensive/
 		# > The registration mark thickness is actually very important. For some reason, 0.3 mm marks work perfectly. 
 		# > The thicker you get, the less accurate registration will be. ~~~ galaxyman47
 		REG_MARK_LINE_WIDTH_MM = 0.3
-		line.set('style', 'stroke: black; stroke-width: '+str(REG_MARK_LINE_WIDTH_MM* self.svg.unittouu('1mm'))+';')
+		line.set('style', 'stroke: black; stroke-width: '+str(REG_MARK_LINE_WIDTH_MM * self.svg.unittouu('1mm'))+';')
 		return line
 	
 	def effect(self):
@@ -73,34 +63,27 @@ class InsertRegmark(inkex.Effect):
 		REG_LINE_MM = 20
 		REG_KEEPOUT_MM = 2
 
-		svg = self.document.getroot()
-
 		reg_origin_X = self.options.regoriginx
 		reg_origin_Y = self.options.regoriginy
-		reg_width = self.options.regwidth if self.options.regwidth else int(svg.get("width").rstrip("mm")) - reg_origin_X*2
-		reg_length = self.options.reglength if self.options.reglength else int(svg.get("height").rstrip("mm")) - reg_origin_Y*2
+		reg_width = self.options.regwidth if self.options.regwidth else int(self.svg.get("width").rstrip("mm")) - reg_origin_X*2
+		reg_length = self.options.reglength if self.options.reglength else int(self.svg.get("height").rstrip("mm")) - reg_origin_Y*2
 
 		if self.options.verbose == True:
-			inkex.base.InkscapeExtension.msg(gettext("[INFO]: page width ")+str(svg.get("width").rstrip("mm")))
-			inkex.base.InkscapeExtension.msg(gettext("[INFO]: page height ")+str(svg.get("height").rstrip("mm")))
+			inkex.base.InkscapeExtension.msg(gettext("[INFO]: page width ")+str(self.svg.get("width").rstrip("mm")))
+			inkex.base.InkscapeExtension.msg(gettext("[INFO]: page height ")+str(self.svg.get("height").rstrip("mm")))
 			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
 			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
 			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
 			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
-		# Create a new layer.
-		layer = etree.SubElement(svg, 'g')
-		layer.set(inkex.addNS('label', 'inkscape'), self.layername)
-		layer.set(inkex.addNS('groupmode', 'inkscape'), 'layer')
+		# Create a new layer
+		layer = self.svg.add(inkex.Layer.new(self.layername))
 	
 		# Create square in top left corner
 		layer.append(self.drawRect((REG_SQUARE_MM,REG_SQUARE_MM), (reg_origin_X,reg_origin_Y), 'TopLeft'))
 		
 		# Create group for top right corner
-		topRight = inkex.Group()
-		topRight.set('id', 'TopRight')
-		topRight.set('style', 'fill: black;')
-		
+		topRight = inkex.Group(id = 'TopRight', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_right_reg_origin_x = reg_origin_X+reg_width
 		topRight.append(self.drawLine((top_right_reg_origin_x-REG_LINE_MM,reg_origin_Y), (top_right_reg_origin_x,reg_origin_Y), 'Horizontal'))
@@ -108,10 +91,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topRight)
 		
 		# Create group for top right corner
-		bottomLeft = inkex.Group()
-		bottomLeft.set('id', 'BottomLeft')
-		bottomLeft.set('style', 'fill: black;')
-		
+		bottomLeft = inkex.Group(id = 'BottomLeft', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_right_reg_origin_y = reg_origin_Y+reg_length
 		bottomLeft.append(self.drawLine((reg_origin_X,top_right_reg_origin_y), (reg_origin_X+REG_LINE_MM,top_right_reg_origin_y), 'Horizontal'))
@@ -121,10 +101,7 @@ class InsertRegmark(inkex.Effect):
 		# Keepout Marker #
 
 		# Create group for top left corner keepout
-		topLeftKeepout = inkex.Group()
-		topLeftKeepout.set('id', 'TopLeftKeepout')
-		topLeftKeepout.set('style', 'fill: black;')
-
+		topLeftKeepout = inkex.Group(id = 'TopLeftKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_left_keepout_origin_x = reg_origin_X+REG_LINE_MM
 		top_left_keepout_origin_y = reg_origin_Y+REG_LINE_MM
@@ -133,10 +110,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topLeftKeepout)
 
 		# Create group for top right corner keepout
-		topRightKeepout = inkex.Group()
-		topRightKeepout.set('id', 'TopRightKeepout')
-		topRightKeepout.set('style', 'fill: black;')
-
+		topRightKeepout = inkex.Group(id = 'TopRightKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_left_keepout_origin_x = reg_origin_X+reg_width-REG_LINE_MM
 		top_left_keepout_origin_y = reg_origin_Y+REG_LINE_MM
@@ -145,10 +119,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topRightKeepout)
 
 		# Create group for bottom right corner keepout
-		bottomRightKeepout = inkex.Group()
-		bottomRightKeepout.set('id', 'BottomRightKeepout')
-		bottomRightKeepout.set('style', 'fill: black;')
-
+		bottomRightKeepout = inkex.Group(id = 'BottomRightKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		bottom_right_keepout_origin_x = reg_origin_X+REG_LINE_MM
 		bottom_right_keepout_origin_y = reg_origin_Y+reg_length-REG_LINE_MM

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -65,7 +65,10 @@ class InsertRegmark(inkex.Effect):
 		line.set('x2', str(x2))
 		line.set('y2', str(y2))
 		line.set('id', name)
-		line.set('style', 'stroke: black; stroke-width: 0.5;')
+		# https://www.reddit.com/r/silhouettecutters/comments/wcdnzy/the_key_to_print_and_cut_success_an_extensive/
+		# > The registration mark thickness is actually very important. For some reason, 0.3 mm marks work perfectly. 
+		# > The thicker you get, the less accurate registration will be. ~~~ galaxyman47
+		line.set('style', 'stroke: black; stroke-width: 0.3;')
 		return line
 	
 	def effect(self):

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -42,9 +42,7 @@ class InsertRegmark(inkex.Effect):
 	def drawRect(self, size, pos, name):
 		x, y = [pos * self.svg.unittouu('1mm') for pos in pos  ]
 		w, h = [pos * self.svg.unittouu('1mm') for pos in size ]
-		rect = inkex.Rectangle.new(x, y, w, h, id=name)
-		rect.set('style', 'fill: black;')
-		return rect
+		return inkex.Rectangle.new(x, y, w, h, id=name, style='fill: black;')
 		
 	#SVG line element generation routine
 	def drawLine(self, posStart, posEnd, name):

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -37,6 +37,8 @@ class InsertRegmark(inkex.Effect):
 		# > The thicker you get, the less accurate registration will be. ~~~ galaxyman47
 		self.REG_MARK_LINE_WIDTH_MM = 0.3
 
+		self.mm_to_user_unit = self.svg.unittouu('1mm')
+
 	def add_arguments(self, pars):
 		# Parse arguments
 		pars.add_argument("-X", "--reg-x", "--regwidth",  type = float, dest = "regwidth",   default = 180.0, help="X mark distance [mm]")
@@ -47,15 +49,15 @@ class InsertRegmark(inkex.Effect):
 
 	#SVG rect element generation routine
 	def drawRect(self, size, pos, name):
-		x, y = [pos * self.svg.unittouu('1mm') for pos in pos  ]
-		w, h = [pos * self.svg.unittouu('1mm') for pos in size ]
+		x, y = [pos * self.mm_to_user_unit for pos in pos  ]
+		w, h = [pos * self.mm_to_user_unit for pos in size ]
 		return inkex.Rectangle.new(x, y, w, h, id=name, style='fill: black;')
 		
 	#SVG line element generation routine
 	def drawLine(self, posStart, posEnd, name):
-		x1, y1, = [pos * self.svg.unittouu('1mm') for pos in posStart]
-		x2, y2, = [pos * self.svg.unittouu('1mm') for pos in posEnd  ]
-		line_style = 'stroke: black; stroke-width: '+str(self.REG_MARK_LINE_WIDTH_MM * self.svg.unittouu('1mm'))+';'
+		x1, y1, = [pos * self.mm_to_user_unit for pos in posStart]
+		x2, y2, = [pos * self.mm_to_user_unit for pos in posEnd  ]
+		line_style = 'stroke: black; stroke-width: '+str(self.REG_MARK_LINE_WIDTH_MM * self.mm_to_user_unit)+';'
 		return inkex.Line.new((x1, y1), (x2, y2), id=name, style=line_style)
 	
 	def effect(self):

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -80,17 +80,17 @@ class InsertRegmark(EffectExtension):
 		regmark_layer.transform = Transform(f"scale({mm_to_user_unit}, {mm_to_user_unit})")
 
 		# Create square in top left corner
-		regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id='TopLeft', style='fill: black;'))
+		regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id='TopLeft', style='fill:black;'))
 
 		# Create horizontal and vertical lines in group for top left corner
 		top_left_x = reg_origin_X+reg_width
 		top_left_path = [(top_left_x-REG_LINE_MM,reg_origin_Y), (top_left_x,reg_origin_Y), (top_left_x,reg_origin_Y + REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(top_left_path), id="TopRight", style=f"fill:none; stroke: black; stroke-width: {REG_MARK_LINE_WIDTH_MM}"))
+		regmark_layer.append(PathElement.new(path=self.points_to_svgd(top_left_path), id="TopRight", style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
 
 		# Create horizontal and vertical lines in group for bottom right corner
 		bottom_right_y = reg_origin_Y+reg_length
 		bottom_right_path = [(reg_origin_X+REG_LINE_MM,bottom_right_y), (reg_origin_X,bottom_right_y), (reg_origin_X,bottom_right_y - REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(bottom_right_path), id="BottomRight", style=f"fill:none; stroke: black; stroke-width: {REG_MARK_LINE_WIDTH_MM}"))
+		regmark_layer.append(PathElement.new(path=self.points_to_svgd(bottom_right_path), id="BottomRight", style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
 
 		# Safe Area Marker #
 		# This draws the safe drawing area
@@ -112,7 +112,7 @@ class InsertRegmark(EffectExtension):
 			(bottom_right_safearea_origin_x,bottom_right_safearea_origin_y),
 			(bottom_right_safearea_origin_x-REG_SAFE_AREA_MM,bottom_right_safearea_origin_y),
 		]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(safe_area_points), id="SafeArea", style='display:inline;fill:#ffffff;stroke:none;stroke-dasharray:1, 1'))
+		regmark_layer.append(PathElement.new(path=self.points_to_svgd(safe_area_points), id="SafeArea", style='fill:white;stroke:none'))
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -83,13 +83,13 @@ class InsertRegmark(EffectExtension):
 		regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id='TopLeft', style='fill: black;'))
 
 		# Create horizontal and vertical lines in group for top left corner
-		top_left_reg_origin_x = reg_origin_X+reg_width
-		top_left_path = [(top_left_reg_origin_x-REG_LINE_MM,reg_origin_Y), (top_left_reg_origin_x,reg_origin_Y), (top_left_reg_origin_x,reg_origin_Y + REG_LINE_MM)]
+		top_left_x = reg_origin_X+reg_width
+		top_left_path = [(top_left_x-REG_LINE_MM,reg_origin_Y), (top_left_x,reg_origin_Y), (top_left_x,reg_origin_Y + REG_LINE_MM)]
 		regmark_layer.append(PathElement.new(path=self.points_to_svgd(top_left_path), id="TopRight", style=f"fill:none; stroke: black; stroke-width: {REG_MARK_LINE_WIDTH_MM}"))
 
 		# Create horizontal and vertical lines in group for bottom right corner
-		bottom_right_reg_origin_y = reg_origin_Y+reg_length
-		bottom_right_path = [(reg_origin_X+REG_LINE_MM,bottom_right_reg_origin_y), (reg_origin_X,bottom_right_reg_origin_y), (reg_origin_X,bottom_right_reg_origin_y - REG_LINE_MM)]
+		bottom_right_y = reg_origin_Y+reg_length
+		bottom_right_path = [(reg_origin_X+REG_LINE_MM,bottom_right_y), (reg_origin_X,bottom_right_y), (reg_origin_X,bottom_right_y - REG_LINE_MM)]
 		regmark_layer.append(PathElement.new(path=self.points_to_svgd(bottom_right_path), id="BottomRight", style=f"fill:none; stroke: black; stroke-width: {REG_MARK_LINE_WIDTH_MM}"))
 
 		# Safe Area Marker #

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -47,10 +47,10 @@ ENABLE_CHECKERBOARD = True
 class InsertRegmark(EffectExtension):
 	def add_arguments(self, pars):
 		# Parse arguments
-		pars.add_argument("-X", "--reg-x", "--regwidth",  type = float, dest = "regwidth",   default = 180.0, help="X mark distance [mm]")
-		pars.add_argument("-Y", "--reg-y", "--reglength", type = float, dest = "reglength",  default = 230.0, help="Y mark distance [mm]")
-		pars.add_argument("--rego-x",  "--regoriginx",    type = float, dest = "regoriginx", default = 15.0,  help="X mark origin from left [mm]")
-		pars.add_argument("--rego-y", "--regoriginy",     type = float, dest = "regoriginy", default = 20.0,  help="X mark origin from top [mm]")
+		pars.add_argument("-X", "--reg-x", "--regwidth",  type = float, dest = "regwidth",   default = 0.0, help="X mark distance [mm]")
+		pars.add_argument("-Y", "--reg-y", "--reglength", type = float, dest = "reglength",  default = 0.0, help="Y mark distance [mm]")
+		pars.add_argument("--rego-x",  "--regoriginx",    type = float, dest = "regoriginx", default = 10.0,  help="X mark origin from left [mm]")
+		pars.add_argument("--rego-y", "--regoriginy",     type = float, dest = "regoriginy", default = 10.0,  help="X mark origin from top [mm]")
 		pars.add_argument("--verbose", dest = "verbose",  type = Boolean, default = False, help="enable log messages")
 
 	def effect(self):

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -81,12 +81,12 @@ class InsertRegmark(inkex.Effect):
 		reg_length = self.options.reglength if self.options.reglength else int(svg.get("height").rstrip("mm")) - reg_origin_Y*2
 
 		if self.options.verbose == True:
-			inkex.utils.debug(gettext("[INFO]: page width ")+str(svg.get("width").rstrip("mm")))
-			inkex.utils.debug(gettext("[INFO]: page height ")+str(svg.get("height").rstrip("mm")))
-			inkex.utils.debug(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
-			inkex.utils.debug(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
-			inkex.utils.debug(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
-			inkex.utils.debug(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
+			inkex.base.InkscapeExtension.msg(gettext("[INFO]: page width ")+str(svg.get("width").rstrip("mm")))
+			inkex.base.InkscapeExtension.msg(gettext("[INFO]: page height ")+str(svg.get("height").rstrip("mm")))
+			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
+			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
+			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
+			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
 		# Create a new layer.
 		layer = etree.SubElement(svg, 'g')

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -20,6 +20,7 @@ Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 """
 
 import inkex
+from inkex.extensions import EffectExtension
 from inkex import Boolean, Rectangle, Line, PathElement
 from inkex import Layer, Group
 from gettext import gettext
@@ -46,9 +47,9 @@ def points_to_svgd(p):
 	svgd += "z"
 	return svgd
 
-class InsertRegmark(inkex.EffectExtension):
+class InsertRegmark(EffectExtension):
 	def __init__(self):
-		inkex.EffectExtension.__init__(self)
+		EffectExtension.__init__(self)
 
 	def add_arguments(self, pars):
 		# Parse arguments

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -72,7 +72,6 @@ class InsertRegmark(EffectExtension):
 			self.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
 			self.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
-
 		# Register Mark #
 		mm_to_user_unit = self.svg.unittouu('1mm')
 
@@ -115,14 +114,8 @@ class InsertRegmark(EffectExtension):
 		regmark_layer.append(PathElement.new(path=self.points_to_svgd(safe_area_points), id="SafeArea", style='display:inline;fill:#ffffff;stroke:none;stroke-dasharray:1, 1'))
 
 		# Add some settings reminders to the print layer as a reminder
-		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; "
-		safe_area_note += f"mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		safeare_notes_text_element = TextElement(id = 'RegMarkNotes')
-		safeare_notes_text_element.text = safe_area_note
-		safeare_notes_text_element.set('x', (top_left_safearea_origin_x+3) * self.svg.unittouu('1mm'))
-		safeare_notes_text_element.set('y', (bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))*self.svg.unittouu('1mm'))
-		safeare_notes_text_element.set('font-size', 2.5 * self.svg.unittouu('1mm'))
-		regmark_layer.append(safeare_notes_text_element)
+		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
+		regmark_layer.append(TextElement(safe_area_note, x=f"{(top_left_safearea_origin_x+3)*mm_to_user_unit}", y=f"{(bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))*mm_to_user_unit}", id = 'RegMarkNotes', style=f"font-size:{2.5*self.svg.unittouu('1mm')}px"))
 
 		# Lock Layer
 		regmark_layer.set_sensitive(False)

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -40,12 +40,9 @@ REG_SAFE_AREA_MM = 20
 # > The thicker you get, the less accurate registration will be. ~~~ galaxyman47
 REG_MARK_LINE_WIDTH_MM = 0.3
 
-REG_MARK_INFO_FONT_SIZE_PT = 2.5
+REG_MARK_INFO_FONT_SIZE_PX = 2.5
 
 class InsertRegmark(EffectExtension):
-	def __init__(self):
-		EffectExtension.__init__(self)
-
 	def add_arguments(self, pars):
 		# Parse arguments
 		pars.add_argument("-X", "--reg-x", "--regwidth",  type = float, dest = "regwidth",   default = 180.0, help="X mark distance [mm]")
@@ -53,17 +50,6 @@ class InsertRegmark(EffectExtension):
 		pars.add_argument("--rego-x",  "--regoriginx",    type = float, dest = "regoriginx", default = 15.0,  help="X mark origin from left [mm]")
 		pars.add_argument("--rego-y", "--regoriginy",     type = float, dest = "regoriginy", default = 20.0,  help="X mark origin from top [mm]")
 		pars.add_argument("--verbose", dest = "verbose",  type = Boolean, default = False, help="enable log messages")
-
-	#SVG SVGd from (x,y) dimentional points
-	def points_to_svgd(self, p, capped=False):
-		f = p[0]
-		p = p[1:]
-		svgd = "M{:.5f},{:.5f}".format(f[0], f[1])
-		for x in p:
-			svgd += " L{:.5f},{:.5f}".format(x[0], x[1])
-		if capped:
-			svgd += "z"
-		return svgd
 
 	def effect(self):
 		reg_origin_X = self.options.regoriginx
@@ -92,12 +78,12 @@ class InsertRegmark(EffectExtension):
 		# Create horizontal and vertical lines in group for top right corner
 		top_right_x = reg_origin_X+reg_width
 		top_right_path = [(top_right_x-REG_LINE_MM,reg_origin_Y), (top_right_x,reg_origin_Y), (top_right_x,reg_origin_Y + REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(top_right_path), id=REGMARK_TOP_RIGHT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
+		regmark_layer.append(PathElement.new(path="M"+str(top_right_path), id=REGMARK_TOP_RIGHT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
 
 		# Create horizontal and vertical lines in group for bottom left corner
 		bottom_left_y = reg_origin_Y+reg_length
 		bottom_left_path = [(reg_origin_X+REG_LINE_MM,bottom_left_y), (reg_origin_X,bottom_left_y), (reg_origin_X,bottom_left_y - REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(bottom_left_path), id=REGMARK_BOTTOM_LEFT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
+		regmark_layer.append(PathElement.new(path="M"+str(bottom_left_path), id=REGMARK_BOTTOM_LEFT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
 
 		# Safe Area Marker #
 		# This draws the safe drawing area
@@ -119,14 +105,14 @@ class InsertRegmark(EffectExtension):
 			(bottom_left_safearea_origin_x,bottom_left_safearea_origin_y),
 			(bottom_left_safearea_origin_x-REG_SAFE_AREA_MM,bottom_left_safearea_origin_y),
 		]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(safe_area_points, capped=True), id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none'))
+		regmark_layer.append(PathElement.new(path="M"+str(safe_area_points)+"z", id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none'))
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		regmark_layer.append(TextElement(safe_area_note, x=f"{(bottom_left_safearea_origin_x+3)}", y=f"{(bottom_left_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = REGMARK_NOTES_ID, style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PT}px"))
+		regmark_layer.append(TextElement(safe_area_note, x=f"{(bottom_left_safearea_origin_x+3)}", y=f"{(bottom_left_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = REGMARK_NOTES_ID, style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PX}px"))
 
 		# Lock Layer
 		regmark_layer.set_sensitive(False)
-		
+
 if __name__ == '__main__':
 	InsertRegmark().run()

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -28,7 +28,7 @@ REGMARK_LAYERNAME = 'Regmarks'
 REG_SQUARE_MM = 5
 REG_LINE_MM = 20
 
-SAFEAREA_LAYERNAME = 'Print-SafeArea'
+SAFEAREA_LAYERNAME = 'Print - SafeArea'
 REG_SAFE_AREA_MM = 20
 
 # https://www.reddit.com/r/silhouettecutters/comments/wcdnzy/the_key_to_print_and_cut_success_an_extensive/

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -22,21 +22,19 @@ Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 import inkex
 from gettext import gettext
 
+LAYERNAME = 'Regmarks'
+REG_SQUARE_MM = 5
+REG_LINE_MM = 20
+REG_KEEPOUT_MM = 2
+
+# https://www.reddit.com/r/silhouettecutters/comments/wcdnzy/the_key_to_print_and_cut_success_an_extensive/
+# > The registration mark thickness is actually very important. For some reason, 0.3 mm marks work perfectly. 
+# > The thicker you get, the less accurate registration will be. ~~~ galaxyman47
+REG_MARK_LINE_WIDTH_MM = 0.3
+
 class InsertRegmark(inkex.Effect):
 	def __init__(self):
 		inkex.Effect.__init__(self)
-		
-		# Layer name static, since self.document.getroot() not available on initialization
-		self.LAYERNAME = 'Regmarks'
-		self.REG_SQUARE_MM = 5
-		self.REG_LINE_MM = 20
-		self.REG_KEEPOUT_MM = 2
-
-		# https://www.reddit.com/r/silhouettecutters/comments/wcdnzy/the_key_to_print_and_cut_success_an_extensive/
-		# > The registration mark thickness is actually very important. For some reason, 0.3 mm marks work perfectly. 
-		# > The thicker you get, the less accurate registration will be. ~~~ galaxyman47
-		self.REG_MARK_LINE_WIDTH_MM = 0.3
-
 		self.mm_to_user_unit = self.svg.unittouu('1mm')
 
 	def add_arguments(self, pars):
@@ -57,7 +55,7 @@ class InsertRegmark(inkex.Effect):
 	def drawLine(self, posStart, posEnd, name):
 		x1, y1, = [pos * self.mm_to_user_unit for pos in posStart]
 		x2, y2, = [pos * self.mm_to_user_unit for pos in posEnd  ]
-		line_style = 'stroke: black; stroke-width: '+str(self.REG_MARK_LINE_WIDTH_MM * self.mm_to_user_unit)+';'
+		line_style = 'stroke: black; stroke-width: '+str(REG_MARK_LINE_WIDTH_MM * self.mm_to_user_unit)+';'
 		return inkex.Line.new((x1, y1), (x2, y2), id=name, style=line_style)
 	
 	def effect(self):
@@ -75,25 +73,25 @@ class InsertRegmark(inkex.Effect):
 			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
 		# Create a new layer
-		layer = self.svg.add(inkex.Layer.new(self.LAYERNAME))
+		layer = self.svg.add(inkex.Layer.new(LAYERNAME))
 	
 		# Create square in top left corner
-		layer.append(self.drawRect((self.REG_SQUARE_MM,self.REG_SQUARE_MM), (reg_origin_X,reg_origin_Y), 'TopLeft'))
+		layer.append(self.drawRect((REG_SQUARE_MM,REG_SQUARE_MM), (reg_origin_X,reg_origin_Y), 'TopLeft'))
 		
 		# Create group for top right corner
 		topRight = inkex.Group(id = 'TopRight', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_right_reg_origin_x = reg_origin_X+reg_width
-		topRight.append(self.drawLine((top_right_reg_origin_x-self.REG_LINE_MM,reg_origin_Y), (top_right_reg_origin_x,reg_origin_Y), 'Horizontal'))
-		topRight.append(self.drawLine((top_right_reg_origin_x,reg_origin_Y), (top_right_reg_origin_x,reg_origin_Y + self.REG_LINE_MM), 'Vertical'))
+		topRight.append(self.drawLine((top_right_reg_origin_x-REG_LINE_MM,reg_origin_Y), (top_right_reg_origin_x,reg_origin_Y), 'Horizontal'))
+		topRight.append(self.drawLine((top_right_reg_origin_x,reg_origin_Y), (top_right_reg_origin_x,reg_origin_Y + REG_LINE_MM), 'Vertical'))
 		layer.append(topRight)
 		
 		# Create group for top right corner
 		bottomLeft = inkex.Group(id = 'BottomLeft', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_right_reg_origin_y = reg_origin_Y+reg_length
-		bottomLeft.append(self.drawLine((reg_origin_X,top_right_reg_origin_y), (reg_origin_X+self.REG_LINE_MM,top_right_reg_origin_y), 'Horizontal'))
-		bottomLeft.append(self.drawLine((reg_origin_X,top_right_reg_origin_y), (reg_origin_X,top_right_reg_origin_y - self.REG_LINE_MM), 'Vertical'))
+		bottomLeft.append(self.drawLine((reg_origin_X,top_right_reg_origin_y), (reg_origin_X+REG_LINE_MM,top_right_reg_origin_y), 'Horizontal'))
+		bottomLeft.append(self.drawLine((reg_origin_X,top_right_reg_origin_y), (reg_origin_X,top_right_reg_origin_y - REG_LINE_MM), 'Vertical'))
 		layer.append(bottomLeft)
 		
 		# Keepout Marker #
@@ -101,28 +99,28 @@ class InsertRegmark(inkex.Effect):
 		# Create group for top left corner keepout
 		topLeftKeepout = inkex.Group(id = 'TopLeftKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
-		top_left_keepout_origin_x = reg_origin_X+self.REG_LINE_MM
-		top_left_keepout_origin_y = reg_origin_Y+self.REG_LINE_MM
-		topLeftKeepout.append(self.drawLine((top_left_keepout_origin_x,top_left_keepout_origin_y), (top_left_keepout_origin_x-self.REG_KEEPOUT_MM,top_left_keepout_origin_y),'Horizontal'))
-		topLeftKeepout.append(self.drawLine((top_left_keepout_origin_x,top_left_keepout_origin_y), (top_left_keepout_origin_x,top_left_keepout_origin_y-self.REG_KEEPOUT_MM), 'Vertical'))
+		top_left_keepout_origin_x = reg_origin_X+REG_LINE_MM
+		top_left_keepout_origin_y = reg_origin_Y+REG_LINE_MM
+		topLeftKeepout.append(self.drawLine((top_left_keepout_origin_x,top_left_keepout_origin_y), (top_left_keepout_origin_x-REG_KEEPOUT_MM,top_left_keepout_origin_y),'Horizontal'))
+		topLeftKeepout.append(self.drawLine((top_left_keepout_origin_x,top_left_keepout_origin_y), (top_left_keepout_origin_x,top_left_keepout_origin_y-REG_KEEPOUT_MM), 'Vertical'))
 		layer.append(topLeftKeepout)
 
 		# Create group for top right corner keepout
 		topRightKeepout = inkex.Group(id = 'TopRightKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
-		top_left_keepout_origin_x = reg_origin_X+reg_width-self.REG_LINE_MM
-		top_left_keepout_origin_y = reg_origin_Y+self.REG_LINE_MM
-		topRightKeepout.append(self.drawLine((top_left_keepout_origin_x,top_left_keepout_origin_y), (top_left_keepout_origin_x+self.REG_KEEPOUT_MM,top_left_keepout_origin_y),'Horizontal'))
-		topRightKeepout.append(self.drawLine((top_left_keepout_origin_x,top_left_keepout_origin_y), (top_left_keepout_origin_x,top_left_keepout_origin_y-self.REG_KEEPOUT_MM), 'Vertical'))
+		top_left_keepout_origin_x = reg_origin_X+reg_width-REG_LINE_MM
+		top_left_keepout_origin_y = reg_origin_Y+REG_LINE_MM
+		topRightKeepout.append(self.drawLine((top_left_keepout_origin_x,top_left_keepout_origin_y), (top_left_keepout_origin_x+REG_KEEPOUT_MM,top_left_keepout_origin_y),'Horizontal'))
+		topRightKeepout.append(self.drawLine((top_left_keepout_origin_x,top_left_keepout_origin_y), (top_left_keepout_origin_x,top_left_keepout_origin_y-REG_KEEPOUT_MM), 'Vertical'))
 		layer.append(topRightKeepout)
 
 		# Create group for bottom right corner keepout
 		bottomRightKeepout = inkex.Group(id = 'BottomRightKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
-		bottom_right_keepout_origin_x = reg_origin_X+self.REG_LINE_MM
-		bottom_right_keepout_origin_y = reg_origin_Y+reg_length-self.REG_LINE_MM
-		bottomRightKeepout.append(self.drawLine((bottom_right_keepout_origin_x,bottom_right_keepout_origin_y), (bottom_right_keepout_origin_x-self.REG_KEEPOUT_MM,bottom_right_keepout_origin_y),'Horizontal'))
-		bottomRightKeepout.append(self.drawLine((bottom_right_keepout_origin_x,bottom_right_keepout_origin_y), (bottom_right_keepout_origin_x,bottom_right_keepout_origin_y+self.REG_KEEPOUT_MM), 'Vertical'))
+		bottom_right_keepout_origin_x = reg_origin_X+REG_LINE_MM
+		bottom_right_keepout_origin_y = reg_origin_Y+reg_length-REG_LINE_MM
+		bottomRightKeepout.append(self.drawLine((bottom_right_keepout_origin_x,bottom_right_keepout_origin_y), (bottom_right_keepout_origin_x-REG_KEEPOUT_MM,bottom_right_keepout_origin_y),'Horizontal'))
+		bottomRightKeepout.append(self.drawLine((bottom_right_keepout_origin_x,bottom_right_keepout_origin_y), (bottom_right_keepout_origin_x,bottom_right_keepout_origin_y+REG_KEEPOUT_MM), 'Vertical'))
 		layer.append(bottomRightKeepout)
 
 		# Lock layer

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -47,7 +47,7 @@ class InsertRegmark(inkex.Effect):
 	def drawRect(self, size, pos, name):
 		x, y = [pos * self.svg.unittouu('1mm') for pos in pos  ]
 		w, h = [pos * self.svg.unittouu('1mm') for pos in size ]
-		rect = etree.Element('{%s}rect' % SVG_URI)
+		rect = inkex.Rectangle()
 		rect.set('x', str(x))
 		rect.set('y', str(y))
 		rect.set('id', name)
@@ -60,7 +60,7 @@ class InsertRegmark(inkex.Effect):
 	def drawLine(self, posStart, posEnd, name):
 		x1, y1, = [pos * self.svg.unittouu('1mm') for pos in posStart]
 		x2, y2, = [pos * self.svg.unittouu('1mm') for pos in posEnd  ]
-		line = etree.Element('{%s}line' % SVG_URI)
+		line = inkex.Line()
 		line.set('x1', str(x1))
 		line.set('y1', str(y1))
 		line.set('x2', str(x2))

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -44,7 +44,8 @@ if not hasattr(inkex, "__version__") or inkex.__version__[0:3] < "1.2":
 	SvgDocumentElement._base_scale = lambda self, unit="px": (convert_unit(1, unit) or 1.0) if not all(self.get_viewbox()[2:]) else max([convert_unit(self.viewport_width, unit) / self.get_viewbox()[2], convert_unit(self.viewport_height, unit) / self.get_viewbox()[3]]) or convert_unit(1, unit) or 1.0
 	SvgDocumentElement.to_dimensional = staticmethod(lambda self, value, to_unit="px": convert_unit(value, to_unit))
 	SvgDocumentElement.to_dimensionless = staticmethod(lambda self, value: convert_unit(value, "px"))
-	SvgDocumentElement.viewport_to_unit = staticmethod(lambda self, value, unit="px": SvgDocumentElement.to_dimensional(SvgDocumentElement.to_dimensionless(value) / self.root.equivalent_transform_scale, unit))
+	SvgDocumentElement.equivalent_transform_scale = property(lambda self: max([self.to_dimensional(self.viewport_width, unit) / self.viewbox_width, self.to_dimensional(self.viewport_height, unit) / self.viewbox_height]) or 1.0)
+	SvgDocumentElement.viewport_to_unit = staticmethod(lambda self, value, unit="px": self.to_dimensional(self.to_dimensionless(value) / self.root.equivalent_transform_scale, unit))
 
 REGMARK_LAYERNAME = 'Regmarks'
 REGMARK_LAYER_ID = 'regmark'

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -84,12 +84,12 @@ class InsertRegmark(inkex.Effect):
 		reg_length = self.options.reglength if self.options.reglength else int(svg.get("height").rstrip("mm")) - reg_origin_Y*2
 
 		if self.options.verbose == True:
-			inkex.errormsg(gettext("[INFO]: page width ")+str(svg.get("width").rstrip("mm")))
-			inkex.errormsg(gettext("[INFO]: page height ")+str(svg.get("height").rstrip("mm")))
-			inkex.errormsg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
-			inkex.errormsg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
-			inkex.errormsg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
-			inkex.errormsg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
+			inkex.utils.debug(gettext("[INFO]: page width ")+str(svg.get("width").rstrip("mm")))
+			inkex.utils.debug(gettext("[INFO]: page height ")+str(svg.get("height").rstrip("mm")))
+			inkex.utils.debug(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
+			inkex.utils.debug(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
+			inkex.utils.debug(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
+			inkex.utils.debug(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
 		# Create a new layer.
 		layer = etree.SubElement(svg, 'g')

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -1,0 +1,119 @@
+#
+# Copyright (C) 2021 miLORD1337
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA.
+#
+"""
+Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
+"""
+
+import inkex
+from lxml import etree
+from gettext import gettext
+
+SVG_URI = u'http://www.w3.org/2000/svg'
+
+class InsertRegmark(inkex.Effect):
+	def __init__(self):
+		inkex.Effect.__init__(self)
+		
+		# Layer name static, since self.document.getroot() not available on initialization
+		self.layername = 'silhouette-regmark'
+		
+		# Parse arguments
+		self.arg_parser.add_argument("-X", "--reg-x", "--regwidth", 
+				type = float, dest = "regwidth", default = 180.0, help="X mark distance [mm]")
+		self.arg_parser.add_argument("-Y", "--reg-y", "--reglength", 
+				type = float, dest = "reglength", default = 230.0, help="Y mark distance [mm]")
+		self.arg_parser.add_argument("--rego-x",  "--regoriginx", 
+				type = float, dest = "regoriginx", default = 15.0, help="X mark origin from left [mm]")
+		self.arg_parser.add_argument("--rego-y", "--regoriginy", 
+				type = float, dest = "regoriginy", default = 20.0, help="X mark origin from top [mm]")
+	
+	#SVG rect element generation routine
+	def drawRect(self, size, pos, name):
+		x, y = pos
+		w, h = size
+		rect = etree.Element('{%s}rect' % SVG_URI)
+		rect.set('x', str(x))
+		rect.set('y', str(y))
+		rect.set('id', name)
+		rect.set('width', str(w))
+		rect.set('height', str(h))
+		rect.set('style', 'fill: black;')
+		return rect
+		
+	#SVG line element generation routine
+	def drawLine(self, posStart, posEnd, name):
+		x1, y1 = posStart
+		x2, y2, = posEnd
+		line = etree.Element('{%s}line' % SVG_URI)
+		line.set('x1', str(x1))
+		line.set('y1', str(y1))
+		line.set('x2', str(x2))
+		line.set('y2', str(y2))
+		line.set('id', name)
+		line.set('style', 'stroke: black; stroke-width: 0.5;')
+		return line
+	
+	def effect(self):
+		REG_SQUARE_MM = 5
+		REG_LINE_MM = 20
+
+		svg = self.document.getroot()
+
+		regwidth = self.options.regwidth if self.options.regwidth else int(svg.get("width").rstrip("mm")) - self.options.regoriginx*2
+		reglength = self.options.reglength if self.options.reglength else int(svg.get("height").rstrip("mm")) - self.options.regoriginy*2
+
+		#inkex.errormsg(gettext("[INFO]: width ")+str(svg.get("width").rstrip("mm")))
+		#inkex.errormsg(gettext("[INFO]: height ")+str(svg.get("height").rstrip("mm")))
+		#inkex.errormsg(gettext("[INFO]: gap width ")+str(regwidth))
+		#inkex.errormsg(gettext("[INFO]: gap height ")+str(reglength))
+
+		# Create a new layer.
+		layer = etree.SubElement(svg, 'g')
+		layer.set(inkex.addNS('label', 'inkscape'), self.layername)
+		layer.set(inkex.addNS('groupmode', 'inkscape'), 'layer')
+	
+		# Create square in top left corner
+		layer.append(self.drawRect((REG_SQUARE_MM,REG_SQUARE_MM), (self.options.regoriginx,self.options.regoriginy), 'TopLeft'))
+		
+		# Create group for top right corner
+		topRight = etree.Element('{%s}g' % SVG_URI)
+		topRight.set('id', 'TopRight')
+		topRight.set('style', 'fill: black;')
+		
+		# Create horizontal and vertical lines in group
+		top_right_reg_origin_x = self.options.regoriginx+regwidth
+		topRight.append(self.drawLine((top_right_reg_origin_x-REG_LINE_MM,self.options.regoriginy), (top_right_reg_origin_x,self.options.regoriginy), 'Horizontal'))
+		topRight.append(self.drawLine((top_right_reg_origin_x,self.options.regoriginy), (top_right_reg_origin_x,self.options.regoriginy + REG_LINE_MM), 'Vertical'))
+		layer.append(topRight)
+		
+		# Create group for top right corner
+		bottomLeft = etree.Element('{%s}g' % SVG_URI)
+		bottomLeft.set('id', 'BottomLeft')
+		bottomLeft.set('style', 'fill: black;')
+		
+		# Create horizontal and vertical lines in group
+		top_right_reg_origin_y = self.options.regoriginy+reglength
+		bottomLeft.append(self.drawLine((self.options.regoriginx,top_right_reg_origin_y), (self.options.regoriginx+REG_LINE_MM,top_right_reg_origin_y), 'Horizontal'))
+		bottomLeft.append(self.drawLine((self.options.regoriginx,top_right_reg_origin_y), (self.options.regoriginx,top_right_reg_origin_y - REG_LINE_MM), 'Vertical'))
+		layer.append(bottomLeft)
+		
+		#Lock layer
+		layer.set(inkex.addNS('insensitive', 'sodipodi'), 'true') 
+		
+if __name__ == '__main__':
+	InsertRegmark().run()

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -20,9 +20,7 @@ Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 """
 
 import inkex
-from inkex.extensions import EffectExtension
-from inkex import Boolean, Rectangle, Line, PathElement
-from inkex import Layer, Group, TextElement
+from inkex import EffectExtension, Boolean, Rectangle, Line, PathElement, Layer, Group, TextElement
 from gettext import gettext
 
 REGMARK_LAYERNAME = 'Regmarks'
@@ -81,12 +79,12 @@ class InsertRegmark(EffectExtension):
 		reg_length = self.options.reglength if self.options.reglength else int(self.svg.get("height").rstrip("mm")) - reg_origin_Y*2
 
 		if self.options.verbose == True:
-			inkex.base.InkscapeExtension.msg(gettext("[INFO]: page width ")+str(self.svg.get("width").rstrip("mm")))
-			inkex.base.InkscapeExtension.msg(gettext("[INFO]: page height ")+str(self.svg.get("height").rstrip("mm")))
-			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
-			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
-			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
-			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
+			self.msg(gettext("[INFO]: page width ")+str(self.svg.get("width").rstrip("mm")))
+			self.msg(gettext("[INFO]: page height ")+str(self.svg.get("height").rstrip("mm")))
+			self.msg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
+			self.msg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
+			self.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
+			self.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
 
 		# Register Mark #

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -68,7 +68,7 @@ class InsertRegmark(EffectExtension):
 			self.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
 		# Check if existing regmark layer exist and delete it
-		old_regmark_layer = self.svg.getElementById("regmark")
+		old_regmark_layer = self.svg.getElementById(REGMARK_LAYER_ID)
 		if old_regmark_layer is not None:
 			old_regmark_layer.delete()
 

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -72,7 +72,7 @@ class InsertRegmark(EffectExtension):
 
 		# Create a new register mark layer
 		regmark_layer = Layer.new(REGMARK_LAYERNAME, id=REGMARK_LAYER_ID)
-		regmark_layer.transform = Transform(f"scale({mm_to_user_unit}, {mm_to_user_unit})")
+		regmark_layer.transform = Transform(scale=mm_to_user_unit)
 
 		# Create square in top left corner
 		regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id=REGMARK_TOP_LEFT_ID, style='fill:black;'))

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -35,15 +35,9 @@ import inkex
 from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform, BaseElement
 from gettext import gettext
 
-# Temorary Monkey Patches to support functions that exist only after v1.2
+# Temporary Monkey Patches to support functions that exist only after v1.2
 # TODO: If support for Inkscape v1.1 is dropped then this backport can be removed
 if not hasattr(inkex, "__version__") or inkex.__version__[0:3] < "1.2":
-	# backport https://gitlab.com/inkscape/extensions/-/issues/367
-	BaseElement.uutounit = lambda self, v, *kwargs: float(v)
-	# backport https://gitlab.com/inkscape/extensions/-/merge_requests/433
-	Line.get_path = lambda self: 'M{0[x1]},{0[y1]} L{0[x2]},{0[y2]}'.format(self.attrib)
-	# backport @ matmul operator
-	Transform.__matmul__ = Transform.__mul__
 	# backport svg._base_scale()
 	SvgDocumentElement.viewport_width = property(lambda self: convert_unit(self.get("width"), "px") or self.get_viewbox()[2])
 	SvgDocumentElement.viewport_height = property(lambda self: convert_unit(self.get("height"), "px") or self.get_viewbox()[3])

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -30,7 +30,7 @@ class InsertRegmark(inkex.Effect):
 		inkex.Effect.__init__(self)
 		
 		# Layer name static, since self.document.getroot() not available on initialization
-		self.layername = 'silhouette-regmark'
+		self.layername = 'Regmarks'
 		
 		# Parse arguments
 		self.arg_parser.add_argument("-X", "--reg-x", "--regwidth", 

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -47,8 +47,8 @@ ENABLE_CHECKERBOARD = True
 class InsertRegmark(EffectExtension):
 	def add_arguments(self, pars):
 		# Parse arguments
-		pars.add_argument("-X", "--reg-x", "--regwidth",  type = float, dest = "regwidth",   default = 0.0, help="X mark distance [mm]")
-		pars.add_argument("-Y", "--reg-y", "--reglength", type = float, dest = "reglength",  default = 0.0, help="Y mark distance [mm]")
+		pars.add_argument("-X", "--reg-x", "--regwidth",  type = float, dest = "regwidth",   default = 0.0, help="X mark to mark distance [mm]")
+		pars.add_argument("-Y", "--reg-y", "--reglength", type = float, dest = "reglength",  default = 0.0, help="Y mark to mark distance [mm]")
 		pars.add_argument("--rego-x",  "--regoriginx",    type = float, dest = "regoriginx", default = 10.0,  help="X mark origin from left [mm]")
 		pars.add_argument("--rego-y", "--regoriginy",     type = float, dest = "regoriginy", default = 10.0,  help="X mark origin from top [mm]")
 		pars.add_argument("--verbose", dest = "verbose",  type = Boolean, default = False, help="enable log messages")

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -42,6 +42,8 @@ REG_MARK_LINE_WIDTH_MM = 0.3
 
 REG_MARK_INFO_FONT_SIZE_PX = 2.5
 
+ENABLE_CHECKERBOARD = True
+
 class InsertRegmark(EffectExtension):
 	def add_arguments(self, pars):
 		# Parse arguments
@@ -105,7 +107,7 @@ class InsertRegmark(EffectExtension):
 			(bottom_left_safearea_origin_x,bottom_left_safearea_origin_y),
 			(bottom_left_safearea_origin_x-REG_SAFE_AREA_MM,bottom_left_safearea_origin_y),
 		]
-		regmark_layer.append(PathElement.new(path="M"+str(safe_area_points)+"z", id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none'))
+		regmark_layer.append(PathElement.new(path="M"+str(safe_area_points)+"Z", id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none'))
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
@@ -116,6 +118,9 @@ class InsertRegmark(EffectExtension):
 
 		# Insert regmark layer to the bottom of the svg layer stack to avoid covering any existing artwork
 		self.svg.insert(0, regmark_layer)
+
+		# Set Page Setting to enable checkerboard (This is required so that safe area is easier to see)
+		self.svg.namedview.set(inkex.addNS('pagecheckerboard', 'inkscape'), str(ENABLE_CHECKERBOARD).lower())
 
 if __name__ == '__main__':
 	InsertRegmark().run()

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -33,6 +33,8 @@ REG_SAFE_AREA_MM = 20
 # > The thicker you get, the less accurate registration will be. ~~~ galaxyman47
 REG_MARK_LINE_WIDTH_MM = 0.3
 
+REG_MARK_INFO_FONT_SIZE_PT = 2.5
+
 class InsertRegmark(EffectExtension):
 	def __init__(self):
 		EffectExtension.__init__(self)
@@ -114,7 +116,7 @@ class InsertRegmark(EffectExtension):
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		regmark_layer.append(TextElement(safe_area_note, x=f"{(top_left_safearea_origin_x+3)}", y=f"{(bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = 'RegMarkNotes', style=f"font-size:{2.5}px"))
+		regmark_layer.append(TextElement(safe_area_note, x=f"{(top_left_safearea_origin_x+3)}", y=f"{(bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = 'RegMarkNotes', style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PT}px"))
 
 		# Lock Layer
 		regmark_layer.set_sensitive(False)

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -34,6 +34,7 @@ else:   # linux
 import inkex
 from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform, BaseElement, SvgDocumentElement
 from gettext import gettext
+from inkex.units import convert_unit
 
 # Temporary Monkey Backport Patches to support functions that exist only after v1.2
 # TODO: If support for Inkscape v1.1 is dropped then this backport can be removed
@@ -42,7 +43,8 @@ if not hasattr(inkex, "__version__") or inkex.__version__[0:3] < "1.2":
 	SvgDocumentElement.viewport_height = property(lambda self: convert_unit(self.get("height"), "px") or self.get_viewbox()[3])
 	SvgDocumentElement._base_scale = lambda self, unit="px": (convert_unit(1, unit) or 1.0) if not all(self.get_viewbox()[2:]) else max([convert_unit(self.viewport_width, unit) / self.get_viewbox()[2], convert_unit(self.viewport_height, unit) / self.get_viewbox()[3]]) or convert_unit(1, unit) or 1.0
 	SvgDocumentElement.to_dimensional = staticmethod(lambda self, value, to_unit="px": convert_unit(value, to_unit))
-	SvgDocumentElement.viewport_to_unit = staticmethod(lambda self, value, unit="px": self.to_dimensional(self.to_dimensionless(value) / self.root.equivalent_transform_scale, unit))
+	SvgDocumentElement.to_dimensionless = staticmethod(lambda self, value: convert_unit(value, "px"))
+	SvgDocumentElement.viewport_to_unit = staticmethod(lambda self, value, unit="px": SvgDocumentElement.to_dimensional(SvgDocumentElement.to_dimensionless(value) / self.root.equivalent_transform_scale, unit))
 
 REGMARK_LAYERNAME = 'Regmarks'
 REGMARK_LAYER_ID = 'regmark'

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -28,8 +28,6 @@ from gettext import gettext
 REGMARK_LAYERNAME = 'Regmarks'
 REG_SQUARE_MM = 5
 REG_LINE_MM = 20
-
-SAFEAREA_LAYERNAME = 'SafeArea'
 REG_SAFE_AREA_MM = 20
 
 # https://www.reddit.com/r/silhouettecutters/comments/wcdnzy/the_key_to_print_and_cut_success_an_extensive/
@@ -67,11 +65,12 @@ class InsertRegmark(EffectExtension):
 	#SVG SVGd from (x,y) dimentional points
 	def points_to_svgd(self, p):
 		mm_to_user_unit = self.svg.unittouu('1mm')
+		p = [(x * mm_to_user_unit, y *mm_to_user_unit) for x, y in p]
 		f = p[0]
 		p = p[1:]
-		svgd = "M{:.5f},{:.5f}".format(f[0]*mm_to_user_unit, f[1]*mm_to_user_unit)
+		svgd = "M{:.5f},{:.5f}".format(f[0], f[1])
 		for x in p:
-			svgd += " L{:.5f},{:.5f}".format(x[0]*mm_to_user_unit, x[1]*mm_to_user_unit)
+			svgd += " L{:.5f},{:.5f}".format(x[0], x[1])
 		svgd += "z"
 		return svgd
 

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -32,17 +32,17 @@ else:   # linux
     sys.path.append("/usr/share/inkscape/extensions")
 
 import inkex
-from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform, BaseElement
+from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform, BaseElement, SvgDocumentElement
 from gettext import gettext
 
-# Temporary Monkey Patches to support functions that exist only after v1.2
+# Temporary Monkey Backport Patches to support functions that exist only after v1.2
 # TODO: If support for Inkscape v1.1 is dropped then this backport can be removed
 if not hasattr(inkex, "__version__") or inkex.__version__[0:3] < "1.2":
-	# backport svg._base_scale()
 	SvgDocumentElement.viewport_width = property(lambda self: convert_unit(self.get("width"), "px") or self.get_viewbox()[2])
 	SvgDocumentElement.viewport_height = property(lambda self: convert_unit(self.get("height"), "px") or self.get_viewbox()[3])
 	SvgDocumentElement._base_scale = lambda self, unit="px": (convert_unit(1, unit) or 1.0) if not all(self.get_viewbox()[2:]) else max([convert_unit(self.viewport_width, unit) / self.get_viewbox()[2], convert_unit(self.viewport_height, unit) / self.get_viewbox()[3]]) or convert_unit(1, unit) or 1.0
 	SvgDocumentElement.to_dimensional = staticmethod(lambda self, value, to_unit="px": convert_unit(value, to_unit))
+	SvgDocumentElement.viewport_to_unit = staticmethod(lambda self, value, unit="px": self.to_dimensional(self.to_dimensionless(value) / self.root.equivalent_transform_scale, unit))
 
 REGMARK_LAYERNAME = 'Regmarks'
 REGMARK_LAYER_ID = 'regmark'

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -67,6 +67,11 @@ class InsertRegmark(EffectExtension):
 			self.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
 			self.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
+		# Check if existing regmark layer exist and delete it
+		old_regmark_layer = self.svg.getElementById("regmark")
+		if old_regmark_layer is not None:
+			old_regmark_layer.delete()
+
 		# Register Mark #
 		mm_to_user_unit = self.svg.unittouu('1mm')
 

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -119,7 +119,7 @@ class InsertRegmark(EffectExtension):
 			(bottom_left_safearea_origin_x,bottom_left_safearea_origin_y),
 			(bottom_left_safearea_origin_x-REG_SAFE_AREA_MM,bottom_left_safearea_origin_y),
 		]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(safe_area_points), id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none'))
+		regmark_layer.append(PathElement.new(path=self.points_to_svgd(safe_area_points, capped=True), id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none'))
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -105,7 +105,7 @@ class InsertRegmark(EffectExtension):
 		topRight.append(self.drawLine((top_right_reg_origin_x,reg_origin_Y), (top_right_reg_origin_x,reg_origin_Y + REG_LINE_MM), 'Vertical'))
 		regmark_layer.append(topRight)
 		
-		# Create horizontal and vertical lines in group for top right corner
+		# Create horizontal and vertical lines in group for bottom left corner
 		bottomLeft = Group(id = 'BottomLeft')
 		top_right_reg_origin_y = reg_origin_Y+reg_length
 		bottomLeft.append(self.drawLine((reg_origin_X,top_right_reg_origin_y), (reg_origin_X+REG_LINE_MM,top_right_reg_origin_y), 'Horizontal'))

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -146,14 +146,13 @@ class InsertRegmark(EffectExtension):
 		safe_area.append(safearea)
 
 		# Add some settings reminders to the print layer as a reminder
-		safe_area_note = ""
-		safe_area_note += f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; "
+		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; "
 		safe_area_note += f"mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
 		safeare_notes_text_element = TextElement()
 		safeare_notes_text_element.text = safe_area_note
-		safeare_notes_text_element.set('x', (top_left_safearea_origin_x+10) * self.svg.unittouu('1mm'))
+		safeare_notes_text_element.set('x', (top_left_safearea_origin_x+3) * self.svg.unittouu('1mm'))
 		safeare_notes_text_element.set('y', (bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))*self.svg.unittouu('1mm'))
-		safeare_notes_text_element.set('font-size', '8')
+		safeare_notes_text_element.set('font-size', 3 * self.svg.unittouu('1mm'))
 		safe_area.append(safeare_notes_text_element)
 
 		# Lock Layer

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -45,8 +45,8 @@ class InsertRegmark(inkex.Effect):
 
 	#SVG rect element generation routine
 	def drawRect(self, size, pos, name):
-		x, y = pos
-		w, h = size
+		x, y = [pos * self.svg.unittouu('1mm') for pos in pos  ]
+		w, h = [pos * self.svg.unittouu('1mm') for pos in size ]
 		rect = etree.Element('{%s}rect' % SVG_URI)
 		rect.set('x', str(x))
 		rect.set('y', str(y))
@@ -58,8 +58,8 @@ class InsertRegmark(inkex.Effect):
 		
 	#SVG line element generation routine
 	def drawLine(self, posStart, posEnd, name):
-		x1, y1 = posStart
-		x2, y2, = posEnd
+		x1, y1, = [pos * self.svg.unittouu('1mm') for pos in posStart]
+		x2, y2, = [pos * self.svg.unittouu('1mm') for pos in posEnd  ]
 		line = etree.Element('{%s}line' % SVG_URI)
 		line.set('x1', str(x1))
 		line.set('y1', str(y1))
@@ -69,7 +69,8 @@ class InsertRegmark(inkex.Effect):
 		# https://www.reddit.com/r/silhouettecutters/comments/wcdnzy/the_key_to_print_and_cut_success_an_extensive/
 		# > The registration mark thickness is actually very important. For some reason, 0.3 mm marks work perfectly. 
 		# > The thicker you get, the less accurate registration will be. ~~~ galaxyman47
-		line.set('style', 'stroke: black; stroke-width: 0.3;')
+		REG_MARK_LINE_WIDTH_MM = 0.3
+		line.set('style', 'stroke: black; stroke-width: '+str(REG_MARK_LINE_WIDTH_MM* self.svg.unittouu('1mm'))+';')
 		return line
 	
 	def effect(self):

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -20,6 +20,7 @@ Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 """
 
 import inkex
+from inkex import Boolean, Rectangle, Line
 from gettext import gettext
 
 LAYERNAME = 'Regmarks'
@@ -35,7 +36,6 @@ REG_MARK_LINE_WIDTH_MM = 0.3
 class InsertRegmark(inkex.Effect):
 	def __init__(self):
 		inkex.Effect.__init__(self)
-		self.mm_to_user_unit = self.svg.unittouu('1mm')
 
 	def add_arguments(self, pars):
 		# Parse arguments
@@ -43,20 +43,22 @@ class InsertRegmark(inkex.Effect):
 		pars.add_argument("-Y", "--reg-y", "--reglength", type = float, dest = "reglength",  default = 230.0, help="Y mark distance [mm]")
 		pars.add_argument("--rego-x",  "--regoriginx",    type = float, dest = "regoriginx", default = 15.0,  help="X mark origin from left [mm]")
 		pars.add_argument("--rego-y", "--regoriginy",     type = float, dest = "regoriginy", default = 20.0,  help="X mark origin from top [mm]")
-		pars.add_argument("--verbose", dest = "verbose",  type = inkex.Boolean, default = False, help="enable log messages")
+		pars.add_argument("--verbose", dest = "verbose",  type = Boolean, default = False, help="enable log messages")
 
 	#SVG rect element generation routine
 	def drawRect(self, size, pos, name):
-		x, y = [pos * self.mm_to_user_unit for pos in pos  ]
-		w, h = [pos * self.mm_to_user_unit for pos in size ]
-		return inkex.Rectangle.new(x, y, w, h, id=name, style='fill: black;')
+		mm_to_user_unit = self.svg.unittouu('1mm')
+		x, y = [pos * mm_to_user_unit for pos in pos  ]
+		w, h = [pos * mm_to_user_unit for pos in size ]
+		return Rectangle.new(x, y, w, h, id=name, style='fill: black;')
 		
 	#SVG line element generation routine
 	def drawLine(self, posStart, posEnd, name):
-		x1, y1, = [pos * self.mm_to_user_unit for pos in posStart]
-		x2, y2, = [pos * self.mm_to_user_unit for pos in posEnd  ]
-		line_style = 'stroke: black; stroke-width: '+str(REG_MARK_LINE_WIDTH_MM * self.mm_to_user_unit)+';'
-		return inkex.Line.new((x1, y1), (x2, y2), id=name, style=line_style)
+		mm_to_user_unit = self.svg.unittouu('1mm')
+		x1, y1, = [pos * mm_to_user_unit for pos in posStart]
+		x2, y2, = [pos * mm_to_user_unit for pos in posEnd  ]
+		line_style = 'stroke: black; stroke-width: '+str(REG_MARK_LINE_WIDTH_MM * mm_to_user_unit)+';'
+		return Line.new((x1, y1), (x2, y2), id=name, style=line_style)
 	
 	def effect(self):
 		reg_origin_X = self.options.regoriginx

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -98,6 +98,8 @@ class InsertRegmark(inkex.Effect):
 		layer.append(bottomLeft)
 		
 		# Keepout Marker #
+		# Not directly part of Silhouette registration marker
+		# Instead it's a visual indicator to the user to avoid putting any design within this area
 
 		# Create group for top left corner keepout
 		topLeftKeepout = Group(id = 'TopLeftKeepout')

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -20,7 +20,6 @@ Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 """
 
 import inkex
-from lxml import etree
 from gettext import gettext
 
 class InsertRegmark(inkex.Effect):

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -19,10 +19,7 @@
 Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 """
 
-import sys, os, inkex
-from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform
-from gettext import gettext
-
+import sys, os
 # Enables stand alone mode and helps for tests #
 # We append the directory where this script lives and inkscape extension folder to sys.path
 sys.path.append(os.path.dirname(os.path.abspath(sys.argv[0])))
@@ -33,6 +30,10 @@ elif sys_platform.startswith("darwin"):
     sys.path.append("/Applications/Inkscape.app/Contents/Resources/share/inkscape/extensions")
 else:   # linux
     sys.path.append("/usr/share/inkscape/extensions")
+
+import inkex
+from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform
+from gettext import gettext
 
 REGMARK_LAYERNAME = 'Regmarks'
 REGMARK_LAYER_ID = 'regmark'

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -159,8 +159,8 @@ class InsertRegmark(inkex.Effect):
 		bottomRightKeepout.append(self.drawLine((bottom_right_keepout_origin_x,bottom_right_keepout_origin_y), (bottom_right_keepout_origin_x,bottom_right_keepout_origin_y+REG_KEEPOUT_MM), 'Vertical'))
 		layer.append(bottomRightKeepout)
 
-		#Lock layer
-		layer.set(inkex.addNS('insensitive', 'sodipodi'), 'true') 
+		# Lock layer
+		layer.set_sensitive(False)
 		
 if __name__ == '__main__':
 	InsertRegmark().run()

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -89,8 +89,8 @@ class InsertRegmark(inkex.Effect):
 			inkex.errormsg(gettext("[INFO]: page height ")+str(svg.get("height").rstrip("mm")))
 			inkex.errormsg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
 			inkex.errormsg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
-			inkex.errormsg(gettext("[INFO]: regmark edge spacing X ")+str(reg_width))
-			inkex.errormsg(gettext("[INFO]: regmark edge spacing Y ")+str(reg_length))
+			inkex.errormsg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
+			inkex.errormsg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
 		# Create a new layer.
 		layer = etree.SubElement(svg, 'g')

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -56,12 +56,12 @@ class InsertRegmark(EffectExtension):
 	def effect(self):
 		reg_origin_X = self.options.regoriginx
 		reg_origin_Y = self.options.regoriginy
-		reg_width = self.options.regwidth if self.options.regwidth else int(self.svg.get("width").rstrip("mm")) - reg_origin_X*2
-		reg_length = self.options.reglength if self.options.reglength else int(self.svg.get("height").rstrip("mm")) - reg_origin_Y*2
+		reg_width = self.options.regwidth if self.options.regwidth else self.svg.to_dimensional(self.svg.get("width"), "mm") - reg_origin_X*2
+		reg_length = self.options.reglength if self.options.reglength else self.svg.to_dimensional(self.svg.get("height"), "mm") - reg_origin_Y*2
 
 		if self.options.verbose == True:
-			self.msg(gettext("[INFO]: page width ")+str(self.svg.get("width").rstrip("mm")))
-			self.msg(gettext("[INFO]: page height ")+str(self.svg.get("height").rstrip("mm")))
+			self.msg(gettext("[INFO]: page width ")+str(self.svg.to_dimensional(self.svg.get("width"), "mm")))
+			self.msg(gettext("[INFO]: page height ")+str(self.svg.to_dimensional(self.svg.get("height"), "mm")))
 			self.msg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
 			self.msg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
 			self.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -20,7 +20,7 @@ Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 """
 
 import inkex
-from inkex import EffectExtension, Boolean, Rectangle, Line, PathElement, Layer, Group, TextElement, Polygon, Transform
+from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform
 from gettext import gettext
 
 REGMARK_LAYERNAME = 'Regmarks'

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -19,9 +19,20 @@
 Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 """
 
-import inkex
+import sys, os, inkex
 from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform
 from gettext import gettext
+
+# Enables stand alone mode and helps for tests #
+# We append the directory where this script lives and inkscape extension folder to sys.path
+sys.path.append(os.path.dirname(os.path.abspath(sys.argv[0])))
+sys_platform = sys.platform.lower()
+if sys_platform.startswith("win"):
+    sys.path.append(r"C:\Program Files\Inkscape\share\inkscape\extensions")
+elif sys_platform.startswith("darwin"):
+    sys.path.append("/Applications/Inkscape.app/Contents/Resources/share/inkscape/extensions")
+else:   # linux
+    sys.path.append("/usr/share/inkscape/extensions")
 
 REGMARK_LAYERNAME = 'Regmarks'
 REGMARK_LAYER_ID = 'regmark'

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -69,7 +69,7 @@ class InsertRegmark(EffectExtension):
 		mm_to_user_unit = self.svg.unittouu('1mm')
 
 		# Create a new register mark layer
-		regmark_layer = self.svg.add(Layer.new(REGMARK_LAYERNAME, id=REGMARK_LAYER_ID))
+		regmark_layer = Layer.new(REGMARK_LAYERNAME, id=REGMARK_LAYER_ID)
 		regmark_layer.transform = Transform(f"scale({mm_to_user_unit}, {mm_to_user_unit})")
 
 		# Create square in top left corner
@@ -113,6 +113,9 @@ class InsertRegmark(EffectExtension):
 
 		# Lock Layer
 		regmark_layer.set_sensitive(False)
+
+		# Insert regmark layer to the bottom of the svg layer stack to avoid covering any existing artwork
+		self.svg.insert(0, regmark_layer)
 
 if __name__ == '__main__':
 	InsertRegmark().run()

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -20,7 +20,7 @@ Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 """
 
 import inkex
-from inkex import EffectExtension, Boolean, Rectangle, Line, PathElement, Layer, Group, TextElement, Polygon
+from inkex import EffectExtension, Boolean, Rectangle, Line, PathElement, Layer, Group, TextElement, Polygon, Transform
 from gettext import gettext
 
 REGMARK_LAYERNAME = 'Regmarks'
@@ -47,8 +47,6 @@ class InsertRegmark(EffectExtension):
 
 	#SVG SVGd from (x,y) dimentional points
 	def points_to_svgd(self, p, capped=False):
-		mm_to_user_unit = self.svg.unittouu('1mm')
-		p = [(x * mm_to_user_unit, y *mm_to_user_unit) for x, y in p]
 		f = p[0]
 		p = p[1:]
 		svgd = "M{:.5f},{:.5f}".format(f[0], f[1])
@@ -77,9 +75,10 @@ class InsertRegmark(EffectExtension):
 
 		# Create a new register mark layer
 		regmark_layer = self.svg.add(Layer.new(REGMARK_LAYERNAME))
+		regmark_layer.transform = Transform(f"scale({mm_to_user_unit}, {mm_to_user_unit})")
 
 		# Create square in top left corner
-		regmark_layer.append(Rectangle.new(left=reg_origin_X*mm_to_user_unit, top=reg_origin_Y*mm_to_user_unit, width=REG_SQUARE_MM*mm_to_user_unit, height=REG_SQUARE_MM*mm_to_user_unit, id='TopLeft', style='fill: black;'))
+		regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id='TopLeft', style='fill: black;'))
 
 		# Create horizontal and vertical lines in group for top left corner
 		top_left_reg_origin_x = reg_origin_X+reg_width
@@ -115,7 +114,7 @@ class InsertRegmark(EffectExtension):
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		regmark_layer.append(TextElement(safe_area_note, x=f"{(top_left_safearea_origin_x+3)*mm_to_user_unit}", y=f"{(bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))*mm_to_user_unit}", id = 'RegMarkNotes', style=f"font-size:{2.5*self.svg.unittouu('1mm')}px"))
+		regmark_layer.append(TextElement(safe_area_note, x=f"{(top_left_safearea_origin_x+3)}", y=f"{(bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = 'RegMarkNotes', style=f"font-size:{2.5}px"))
 
 		# Lock Layer
 		regmark_layer.set_sensitive(False)

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -69,7 +69,7 @@ class InsertRegmark(EffectExtension):
 
 		# Check if existing regmark layer exist and delete it
 		old_regmark_layer = self.svg.getElementById(REGMARK_LAYER_ID)
-		if old_regmark_layer:
+		if old_regmark_layer is not None:
 			old_regmark_layer.delete()
 
 		# Register Mark #

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -24,6 +24,12 @@ from inkex import EffectExtension, Boolean, Rectangle, Line, PathElement, Layer,
 from gettext import gettext
 
 REGMARK_LAYERNAME = 'Regmarks'
+REGMARK_LAYER_ID = 'regmark'
+REGMARK_TOP_LEFT_ID = 'regmark-tl'
+REGMARK_TOP_RIGHT_ID = 'regmark-tr'
+REGMARK_BOTTOM_LEFT_ID = 'regmark-bl'
+REGMARK_SAFE_AREA_ID = 'regmark-safe-area'
+
 REG_SQUARE_MM = 5
 REG_LINE_MM = 20
 REG_SAFE_AREA_MM = 20
@@ -76,21 +82,21 @@ class InsertRegmark(EffectExtension):
 		mm_to_user_unit = self.svg.unittouu('1mm')
 
 		# Create a new register mark layer
-		regmark_layer = self.svg.add(Layer.new(REGMARK_LAYERNAME))
+		regmark_layer = self.svg.add(Layer.new(REGMARK_LAYERNAME, id=REGMARK_LAYER_ID))
 		regmark_layer.transform = Transform(f"scale({mm_to_user_unit}, {mm_to_user_unit})")
 
 		# Create square in top left corner
-		regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id='TopLeft', style='fill:black;'))
+		regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id=REGMARK_TOP_LEFT_ID, style='fill:black;'))
 
-		# Create horizontal and vertical lines in group for top left corner
-		top_left_x = reg_origin_X+reg_width
-		top_left_path = [(top_left_x-REG_LINE_MM,reg_origin_Y), (top_left_x,reg_origin_Y), (top_left_x,reg_origin_Y + REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(top_left_path), id="TopRight", style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
+		# Create horizontal and vertical lines in group for top right corner
+		top_right_x = reg_origin_X+reg_width
+		top_right_path = [(top_right_x-REG_LINE_MM,reg_origin_Y), (top_right_x,reg_origin_Y), (top_right_x,reg_origin_Y + REG_LINE_MM)]
+		regmark_layer.append(PathElement.new(path=self.points_to_svgd(top_right_path), id=REGMARK_TOP_RIGHT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
 
-		# Create horizontal and vertical lines in group for bottom right corner
-		bottom_right_y = reg_origin_Y+reg_length
-		bottom_right_path = [(reg_origin_X+REG_LINE_MM,bottom_right_y), (reg_origin_X,bottom_right_y), (reg_origin_X,bottom_right_y - REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(bottom_right_path), id="BottomRight", style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
+		# Create horizontal and vertical lines in group for bottom left corner
+		bottom_left_y = reg_origin_Y+reg_length
+		bottom_left_path = [(reg_origin_X+REG_LINE_MM,bottom_left_y), (reg_origin_X,bottom_left_y), (reg_origin_X,bottom_left_y - REG_LINE_MM)]
+		regmark_layer.append(PathElement.new(path=self.points_to_svgd(bottom_left_path), id=REGMARK_BOTTOM_LEFT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
 
 		# Safe Area Marker #
 		# This draws the safe drawing area
@@ -98,8 +104,8 @@ class InsertRegmark(EffectExtension):
 		top_left_safearea_origin_y = reg_origin_Y+REG_LINE_MM
 		top_right_safearea_origin_x = reg_origin_X+reg_width-REG_LINE_MM
 		top_right_safearea_origin_y = reg_origin_Y+REG_LINE_MM
-		bottom_right_safearea_origin_x = reg_origin_X+REG_LINE_MM
-		bottom_right_safearea_origin_y = reg_origin_Y+reg_length-REG_LINE_MM
+		bottom_left_safearea_origin_x = reg_origin_X+REG_LINE_MM
+		bottom_left_safearea_origin_y = reg_origin_Y+reg_length-REG_LINE_MM
 		safe_area_points = [
 			(top_left_safearea_origin_x-REG_SAFE_AREA_MM,top_left_safearea_origin_y),
 			(top_left_safearea_origin_x,top_left_safearea_origin_y),
@@ -107,16 +113,16 @@ class InsertRegmark(EffectExtension):
 			(top_right_safearea_origin_x,top_right_safearea_origin_y-REG_SAFE_AREA_MM),
 			(top_right_safearea_origin_x,top_right_safearea_origin_y),
 			(top_right_safearea_origin_x+REG_SAFE_AREA_MM,top_right_safearea_origin_y),
-			(top_right_safearea_origin_x+REG_SAFE_AREA_MM,bottom_right_safearea_origin_y+REG_SAFE_AREA_MM),
-			(bottom_right_safearea_origin_x,bottom_right_safearea_origin_y+REG_SAFE_AREA_MM),
-			(bottom_right_safearea_origin_x,bottom_right_safearea_origin_y),
-			(bottom_right_safearea_origin_x-REG_SAFE_AREA_MM,bottom_right_safearea_origin_y),
+			(top_right_safearea_origin_x+REG_SAFE_AREA_MM,bottom_left_safearea_origin_y+REG_SAFE_AREA_MM),
+			(bottom_left_safearea_origin_x,bottom_left_safearea_origin_y+REG_SAFE_AREA_MM),
+			(bottom_left_safearea_origin_x,bottom_left_safearea_origin_y),
+			(bottom_left_safearea_origin_x-REG_SAFE_AREA_MM,bottom_left_safearea_origin_y),
 		]
-		regmark_layer.append(PathElement.new(path=self.points_to_svgd(safe_area_points), id="SafeArea", style='fill:white;stroke:none'))
+		regmark_layer.append(PathElement.new(path=self.points_to_svgd(safe_area_points), id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none'))
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		regmark_layer.append(TextElement(safe_area_note, x=f"{(top_left_safearea_origin_x+3)}", y=f"{(bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = 'RegMarkNotes', style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PT}px"))
+		regmark_layer.append(TextElement(safe_area_note, x=f"{(bottom_left_safearea_origin_x+3)}", y=f"{(bottom_left_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = 'RegMarkNotes', style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PT}px"))
 
 		# Lock Layer
 		regmark_layer.set_sensitive(False)

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -29,7 +29,7 @@ REGMARK_LAYERNAME = 'Regmarks'
 REG_SQUARE_MM = 5
 REG_LINE_MM = 20
 
-SAFEAREA_LAYERNAME = 'Print - SafeArea'
+SAFEAREA_LAYERNAME = 'SafeArea'
 REG_SAFE_AREA_MM = 20
 
 # https://www.reddit.com/r/silhouettecutters/comments/wcdnzy/the_key_to_print_and_cut_success_an_extensive/
@@ -117,19 +117,14 @@ class InsertRegmark(EffectExtension):
 
 
 		# Safe Area Marker #
-
-		# Create a new register mark layer
-		safe_area = self.svg.add(Layer.new(SAFEAREA_LAYERNAME))
-
 		# This draws the safe drawing area
-		safearea = Group(id = 'SafeArea')
 		top_left_safearea_origin_x = reg_origin_X+REG_LINE_MM
 		top_left_safearea_origin_y = reg_origin_Y+REG_LINE_MM
 		top_right_safearea_origin_x = reg_origin_X+reg_width-REG_LINE_MM
 		top_right_safearea_origin_y = reg_origin_Y+REG_LINE_MM
 		bottom_right_safearea_origin_x = reg_origin_X+REG_LINE_MM
 		bottom_right_safearea_origin_y = reg_origin_Y+reg_length-REG_LINE_MM
-		points = [
+		safe_area_points = [
 			(top_left_safearea_origin_x-REG_SAFE_AREA_MM,top_left_safearea_origin_y),
 			(top_left_safearea_origin_x,top_left_safearea_origin_y),
 			(top_left_safearea_origin_x,top_left_safearea_origin_y-REG_SAFE_AREA_MM),
@@ -141,22 +136,22 @@ class InsertRegmark(EffectExtension):
 			(bottom_right_safearea_origin_x,bottom_right_safearea_origin_y),
 			(bottom_right_safearea_origin_x-REG_SAFE_AREA_MM,bottom_right_safearea_origin_y),
 		]
-		safearea = PathElement(id="safe area", style='display:inline;fill:#ffffff;stroke:none;stroke-dasharray:1, 1')
-		safearea.set_path(self.points_to_svgd(points))
-		safe_area.append(safearea)
+		safearea_polygon = PathElement(id="SafeArea", style='display:inline;fill:#ffffff;stroke:none;stroke-dasharray:1, 1')
+		safearea_polygon.set_path(self.points_to_svgd(safe_area_points))
+		regmark_layer.append(safearea_polygon)
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; "
 		safe_area_note += f"mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		safeare_notes_text_element = TextElement()
+		safeare_notes_text_element = TextElement(id = 'RegMarkNotes')
 		safeare_notes_text_element.text = safe_area_note
 		safeare_notes_text_element.set('x', (top_left_safearea_origin_x+3) * self.svg.unittouu('1mm'))
 		safeare_notes_text_element.set('y', (bottom_right_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))*self.svg.unittouu('1mm'))
-		safeare_notes_text_element.set('font-size', 3 * self.svg.unittouu('1mm'))
-		safe_area.append(safeare_notes_text_element)
+		safeare_notes_text_element.set('font-size', 2.5 * self.svg.unittouu('1mm'))
+		regmark_layer.append(safeare_notes_text_element)
 
 		# Lock Layer
-		safe_area.set_sensitive(False)
+		regmark_layer.set_sensitive(False)
 		
 if __name__ == '__main__':
 	InsertRegmark().run()

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -32,7 +32,7 @@ else:   # linux
     sys.path.append("/usr/share/inkscape/extensions")
 
 import inkex
-from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform
+from inkex import EffectExtension, Boolean, Rectangle, PathElement, Layer, Group, TextElement, Transform, BaseElement
 from gettext import gettext
 
 # Temorary Monkey Patches to support functions that exist only after v1.2
@@ -83,8 +83,8 @@ class InsertRegmark(EffectExtension):
 	def effect(self):
 		reg_origin_X = self.options.regoriginx
 		reg_origin_Y = self.options.regoriginy
-		reg_width = self.options.regwidth if self.options.regwidth else self.svg.to_dimensional(self.svg.viewport_width, "mm") - reg_origin_X * 2
-		reg_length = self.options.reglength if self.options.reglength else self.svg.to_dimensional(self.svg.viewport_height, "mm") - reg_origin_Y * 2
+		reg_width = self.options.regwidth or self.svg.to_dimensional(self.svg.viewport_width, "mm") - reg_origin_X * 2
+		reg_length = self.options.reglength or self.svg.to_dimensional(self.svg.viewport_height, "mm") - reg_origin_Y * 2
 
 		if self.options.verbose == True:
 			self.msg(gettext("[INFO]: page width ")+str(self.svg.to_dimensional(self.svg.viewport_width, "mm")))

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -21,6 +21,7 @@ Base module for rendering regmarks for Silhouette CAMEO products in Inkscape.
 
 import inkex
 from inkex import Boolean, Rectangle, Line
+from inkex import Layer, Group
 from gettext import gettext
 
 LAYERNAME = 'Regmarks'
@@ -75,13 +76,13 @@ class InsertRegmark(inkex.Effect):
 			inkex.base.InkscapeExtension.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
 		# Create a new layer
-		layer = self.svg.add(inkex.Layer.new(LAYERNAME))
+		layer = self.svg.add(Layer.new(LAYERNAME))
 	
 		# Create square in top left corner
 		layer.append(self.drawRect((REG_SQUARE_MM,REG_SQUARE_MM), (reg_origin_X,reg_origin_Y), 'TopLeft'))
 		
 		# Create group for top right corner
-		topRight = inkex.Group(id = 'TopRight', style = 'fill: black;')
+		topRight = Group(id = 'TopRight', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_right_reg_origin_x = reg_origin_X+reg_width
 		topRight.append(self.drawLine((top_right_reg_origin_x-REG_LINE_MM,reg_origin_Y), (top_right_reg_origin_x,reg_origin_Y), 'Horizontal'))
@@ -89,7 +90,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topRight)
 		
 		# Create group for top right corner
-		bottomLeft = inkex.Group(id = 'BottomLeft', style = 'fill: black;')
+		bottomLeft = Group(id = 'BottomLeft', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_right_reg_origin_y = reg_origin_Y+reg_length
 		bottomLeft.append(self.drawLine((reg_origin_X,top_right_reg_origin_y), (reg_origin_X+REG_LINE_MM,top_right_reg_origin_y), 'Horizontal'))
@@ -99,7 +100,7 @@ class InsertRegmark(inkex.Effect):
 		# Keepout Marker #
 
 		# Create group for top left corner keepout
-		topLeftKeepout = inkex.Group(id = 'TopLeftKeepout', style = 'fill: black;')
+		topLeftKeepout = Group(id = 'TopLeftKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_left_keepout_origin_x = reg_origin_X+REG_LINE_MM
 		top_left_keepout_origin_y = reg_origin_Y+REG_LINE_MM
@@ -108,7 +109,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topLeftKeepout)
 
 		# Create group for top right corner keepout
-		topRightKeepout = inkex.Group(id = 'TopRightKeepout', style = 'fill: black;')
+		topRightKeepout = Group(id = 'TopRightKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		top_left_keepout_origin_x = reg_origin_X+reg_width-REG_LINE_MM
 		top_left_keepout_origin_y = reg_origin_Y+REG_LINE_MM
@@ -117,7 +118,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topRightKeepout)
 
 		# Create group for bottom right corner keepout
-		bottomRightKeepout = inkex.Group(id = 'BottomRightKeepout', style = 'fill: black;')
+		bottomRightKeepout = Group(id = 'BottomRightKeepout', style = 'fill: black;')
 		# Create horizontal and vertical lines in group
 		bottom_right_keepout_origin_x = reg_origin_X+REG_LINE_MM
 		bottom_right_keepout_origin_y = reg_origin_Y+reg_length-REG_LINE_MM

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -56,12 +56,12 @@ class InsertRegmark(EffectExtension):
 	def effect(self):
 		reg_origin_X = self.options.regoriginx
 		reg_origin_Y = self.options.regoriginy
-		reg_width = self.options.regwidth if self.options.regwidth else self.svg.to_dimensional(self.svg.get("width"), "mm") - reg_origin_X*2
-		reg_length = self.options.reglength if self.options.reglength else self.svg.to_dimensional(self.svg.get("height"), "mm") - reg_origin_Y*2
+		reg_width = self.options.regwidth if self.options.regwidth else self.svg.to_dimensional(self.svg.viewport_width, "mm") - reg_origin_X * 2
+		reg_length = self.options.reglength if self.options.reglength else self.svg.to_dimensional(self.svg.viewport_height, "mm") - reg_origin_Y * 2
 
 		if self.options.verbose == True:
-			self.msg(gettext("[INFO]: page width ")+str(self.svg.to_dimensional(self.svg.get("width"), "mm")))
-			self.msg(gettext("[INFO]: page height ")+str(self.svg.to_dimensional(self.svg.get("height"), "mm")))
+			self.msg(gettext("[INFO]: page width ")+str(self.svg.to_dimensional(self.svg.viewport_width, "mm")))
+			self.msg(gettext("[INFO]: page height ")+str(self.svg.to_dimensional(self.svg.viewport_height, "mm")))
 			self.msg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
 			self.msg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
 			self.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
@@ -69,11 +69,11 @@ class InsertRegmark(EffectExtension):
 
 		# Check if existing regmark layer exist and delete it
 		old_regmark_layer = self.svg.getElementById(REGMARK_LAYER_ID)
-		if old_regmark_layer is not None:
+		if old_regmark_layer:
 			old_regmark_layer.delete()
 
 		# Register Mark #
-		mm_to_user_unit = self.svg.unittouu('1mm')
+		mm_to_user_unit = self.svg.viewport_to_unit('1mm')
 
 		# Create a new register mark layer
 		regmark_layer = Layer.new(REGMARK_LAYERNAME, id=REGMARK_LAYER_ID)
@@ -85,38 +85,36 @@ class InsertRegmark(EffectExtension):
 		# Create horizontal and vertical lines in group for top right corner
 		top_right_x = reg_origin_X+reg_width
 		top_right_path = [(top_right_x-REG_LINE_MM,reg_origin_Y), (top_right_x,reg_origin_Y), (top_right_x,reg_origin_Y + REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path="M"+str(top_right_path), id=REGMARK_TOP_RIGHT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
+		regmark_layer.append(PathElement.new(path="M"+str(top_right_path), id=REGMARK_TOP_RIGHT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM};"))
 
 		# Create horizontal and vertical lines in group for bottom left corner
 		bottom_left_y = reg_origin_Y+reg_length
 		bottom_left_path = [(reg_origin_X+REG_LINE_MM,bottom_left_y), (reg_origin_X,bottom_left_y), (reg_origin_X,bottom_left_y - REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path="M"+str(bottom_left_path), id=REGMARK_BOTTOM_LEFT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM}"))
+		regmark_layer.append(PathElement.new(path="M"+str(bottom_left_path), id=REGMARK_BOTTOM_LEFT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM};"))
 
 		# Safe Area Marker #
 		# This draws the safe drawing area
-		top_left_safearea_origin_x = reg_origin_X+REG_LINE_MM
-		top_left_safearea_origin_y = reg_origin_Y+REG_LINE_MM
-		top_right_safearea_origin_x = reg_origin_X+reg_width-REG_LINE_MM
-		top_right_safearea_origin_y = reg_origin_Y+REG_LINE_MM
-		bottom_left_safearea_origin_x = reg_origin_X+REG_LINE_MM
-		bottom_left_safearea_origin_y = reg_origin_Y+reg_length-REG_LINE_MM
+		safearea_left_x = reg_origin_X+REG_LINE_MM
+		safearea_top_y = reg_origin_Y+REG_LINE_MM
+		safearea_right_x = reg_origin_X+reg_width-REG_LINE_MM
+		safearea_bottom_y = reg_origin_Y+reg_length-REG_LINE_MM
 		safe_area_points = [
-			(top_left_safearea_origin_x-REG_SAFE_AREA_MM,top_left_safearea_origin_y),
-			(top_left_safearea_origin_x,top_left_safearea_origin_y),
-			(top_left_safearea_origin_x,top_left_safearea_origin_y-REG_SAFE_AREA_MM),
-			(top_right_safearea_origin_x,top_right_safearea_origin_y-REG_SAFE_AREA_MM),
-			(top_right_safearea_origin_x,top_right_safearea_origin_y),
-			(top_right_safearea_origin_x+REG_SAFE_AREA_MM,top_right_safearea_origin_y),
-			(top_right_safearea_origin_x+REG_SAFE_AREA_MM,bottom_left_safearea_origin_y+REG_SAFE_AREA_MM),
-			(bottom_left_safearea_origin_x,bottom_left_safearea_origin_y+REG_SAFE_AREA_MM),
-			(bottom_left_safearea_origin_x,bottom_left_safearea_origin_y),
-			(bottom_left_safearea_origin_x-REG_SAFE_AREA_MM,bottom_left_safearea_origin_y),
+			(safearea_left_x-REG_SAFE_AREA_MM,safearea_top_y),
+			(safearea_left_x,safearea_top_y),
+			(safearea_left_x,safearea_top_y-REG_SAFE_AREA_MM),
+			(safearea_right_x,safearea_top_y-REG_SAFE_AREA_MM),
+			(safearea_right_x,safearea_top_y),
+			(safearea_right_x+REG_SAFE_AREA_MM,safearea_top_y),
+			(safearea_right_x+REG_SAFE_AREA_MM,safearea_bottom_y+REG_SAFE_AREA_MM),
+			(safearea_left_x,safearea_bottom_y+REG_SAFE_AREA_MM),
+			(safearea_left_x,safearea_bottom_y),
+			(safearea_left_x-REG_SAFE_AREA_MM,safearea_bottom_y),
 		]
-		regmark_layer.append(PathElement.new(path="M"+str(safe_area_points)+"Z", id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none'))
+		regmark_layer.append(PathElement.new(path="M"+str(safe_area_points)+"Z", id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none;'))
 
 		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		regmark_layer.append(TextElement(safe_area_note, x=f"{(bottom_left_safearea_origin_x+3)}", y=f"{(bottom_left_safearea_origin_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = REGMARK_NOTES_ID, style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PX}px"))
+		regmark_layer.append(TextElement(safe_area_note, x=f"{(safearea_left_x+3)}", y=f"{(safearea_bottom_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = REGMARK_NOTES_ID, style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PX}px;"))
 
 		# Lock Layer
 		regmark_layer.set_sensitive(False)
@@ -125,7 +123,7 @@ class InsertRegmark(EffectExtension):
 		self.svg.insert(0, regmark_layer)
 
 		# Set Page Setting to enable checkerboard (This is required so that safe area is easier to see)
-		self.svg.namedview.set(inkex.addNS('pagecheckerboard', 'inkscape'), str(ENABLE_CHECKERBOARD).lower())
+		self.svg.namedview.set('inkscape:pagecheckerboard', str(ENABLE_CHECKERBOARD).lower())
 
 if __name__ == '__main__':
 	InsertRegmark().run()

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -82,7 +82,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(self.drawRect((REG_SQUARE_MM,REG_SQUARE_MM), (reg_origin_X,reg_origin_Y), 'TopLeft'))
 		
 		# Create group for top right corner
-		topRight = Group(id = 'TopRight', style = 'fill: black;')
+		topRight = Group(id = 'TopRight')
 		# Create horizontal and vertical lines in group
 		top_right_reg_origin_x = reg_origin_X+reg_width
 		topRight.append(self.drawLine((top_right_reg_origin_x-REG_LINE_MM,reg_origin_Y), (top_right_reg_origin_x,reg_origin_Y), 'Horizontal'))
@@ -90,7 +90,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topRight)
 		
 		# Create group for top right corner
-		bottomLeft = Group(id = 'BottomLeft', style = 'fill: black;')
+		bottomLeft = Group(id = 'BottomLeft')
 		# Create horizontal and vertical lines in group
 		top_right_reg_origin_y = reg_origin_Y+reg_length
 		bottomLeft.append(self.drawLine((reg_origin_X,top_right_reg_origin_y), (reg_origin_X+REG_LINE_MM,top_right_reg_origin_y), 'Horizontal'))
@@ -100,7 +100,7 @@ class InsertRegmark(inkex.Effect):
 		# Keepout Marker #
 
 		# Create group for top left corner keepout
-		topLeftKeepout = Group(id = 'TopLeftKeepout', style = 'fill: black;')
+		topLeftKeepout = Group(id = 'TopLeftKeepout')
 		# Create horizontal and vertical lines in group
 		top_left_keepout_origin_x = reg_origin_X+REG_LINE_MM
 		top_left_keepout_origin_y = reg_origin_Y+REG_LINE_MM
@@ -109,7 +109,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topLeftKeepout)
 
 		# Create group for top right corner keepout
-		topRightKeepout = Group(id = 'TopRightKeepout', style = 'fill: black;')
+		topRightKeepout = Group(id = 'TopRightKeepout')
 		# Create horizontal and vertical lines in group
 		top_left_keepout_origin_x = reg_origin_X+reg_width-REG_LINE_MM
 		top_left_keepout_origin_y = reg_origin_Y+REG_LINE_MM
@@ -118,7 +118,7 @@ class InsertRegmark(inkex.Effect):
 		layer.append(topRightKeepout)
 
 		# Create group for bottom right corner keepout
-		bottomRightKeepout = Group(id = 'BottomRightKeepout', style = 'fill: black;')
+		bottomRightKeepout = Group(id = 'BottomRightKeepout')
 		# Create horizontal and vertical lines in group
 		bottom_right_keepout_origin_x = reg_origin_X+REG_LINE_MM
 		bottom_right_keepout_origin_y = reg_origin_Y+reg_length-REG_LINE_MM

--- a/test/test_render_silhouette_regmark.py
+++ b/test/test_render_silhouette_regmark.py
@@ -5,6 +5,13 @@ from render_silhouette_regmarks import InsertRegmark
 from inkex import BoundingBox
 from inkex.tester import TestCase
 
+REGMARK_LAYERNAME = 'Regmarks'
+REGMARK_LAYER_ID = 'regmark'
+REGMARK_TOP_LEFT_ID = 'regmark-tl'
+REGMARK_TOP_RIGHT_ID = 'regmark-tr'
+REGMARK_BOTTOM_LEFT_ID = 'regmark-bl'
+REGMARK_SAFE_AREA_ID = 'regmark-safe-area'
+REGMARK_NOTES_ID = 'regmark-notes'
 
 class InsertRegmarkTest(TestCase):
     """Tests for Inkscape Extensions"""
@@ -25,32 +32,32 @@ class RegmarkTest(InsertRegmarkTest):
 
         """Ensure top-left regmark"""
         self.assertEqual(
-            self.e.svg.getElementById('regmark-tl').tostring(),
+            self.e.svg.getElementById(REGMARK_TOP_LEFT_ID).tostring(),
             b'<rect x="10.0" y="10.0" width="5" height="5" style="fill:black"/>'
         )
 
         """Ensure top-right regmark"""
         self.assertEqual(
-            self.e.svg.getElementById('regmark-tr').bounding_box(),
+            self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(),
             BoundingBox((390.0, 410.0),(10.0, 30.0))
         )
 
         """Ensure x distance"""
-        transform = self.e.svg.getElementById('regmark-tr').composed_transform()
+        transform = self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).composed_transform()
         self.assertEqual(
             self.e.svg.unit_to_viewport(
-                    (self.e.svg.getElementById('regmark-tr').bounding_box(transform).x.maximum
-                    - self.e.svg.getElementById('regmark-bl').bounding_box(transform).x.minimum),
+                    (self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform).x.maximum
+                    - self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform).x.minimum),
                 "mm"),
             400
         )
 
         """Ensure y distance"""
-        transform = self.e.svg.getElementById('regmark-tr').composed_transform()
+        transform = self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).composed_transform()
         self.assertEqual(
             self.e.svg.unit_to_viewport(
-                    (self.e.svg.getElementById('regmark-bl').bounding_box(transform).y.maximum
-                    - self.e.svg.getElementById('regmark-tr').bounding_box(transform).y.minimum),
+                    (self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform).y.maximum
+                    - self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform).y.minimum),
                 "mm"),
             300
         )

--- a/test/test_render_silhouette_regmark.py
+++ b/test/test_render_silhouette_regmark.py
@@ -4,6 +4,12 @@
 from render_silhouette_regmarks import InsertRegmark
 from inkex import BoundingBox
 from inkex.tester import TestCase
+from pytest import mark
+
+try:
+    from inkex import __version__ as __inkex_version__
+except:
+    __inkex_version__ = "1.1.0_or_smaller_needs_this_hotfix"
 
 REGMARK_LAYERNAME = 'Regmarks'
 REGMARK_LAYER_ID = 'regmark'
@@ -21,6 +27,7 @@ class InsertRegmarkTest(TestCase):
     def setUp(self):
         self.e = self.effect_class()
 
+@mark.xfail(__inkex_version__[0:3] < "1.2", reason="inkex < 1.2 is not supported")
 
 class RegmarkTest(InsertRegmarkTest):
     source_file = "plus_with_duplicate.svg"

--- a/test/test_render_silhouette_regmark.py
+++ b/test/test_render_silhouette_regmark.py
@@ -43,21 +43,19 @@ class RegmarkTest(InsertRegmarkTest):
         )
 
         """Ensure x distance"""
-        transform = self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).composed_transform()
         self.assertEqual(
             self.e.svg.unit_to_viewport(
-                    (self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform).x.maximum
-                    - self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform).x.minimum),
+                    (self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform=True).x.maximum
+                    - self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform=True).x.minimum),
                 "mm"),
             400
         )
 
         """Ensure y distance"""
-        transform = self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).composed_transform()
         self.assertEqual(
             self.e.svg.unit_to_viewport(
-                    (self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform).y.maximum
-                    - self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform).y.minimum),
+                    (self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform=True).y.maximum
+                    - self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform=True).y.minimum),
                 "mm"),
             300
         )

--- a/test/test_render_silhouette_regmark.py
+++ b/test/test_render_silhouette_regmark.py
@@ -27,7 +27,7 @@ class InsertRegmarkTest(TestCase):
     def setUp(self):
         self.e = self.effect_class()
 
-@mark.xfail(__inkex_version__[0:3] < "1.2", reason="inkex < 1.2 is not supported")
+#@mark.xfail(__inkex_version__[0:3] < "1.2", reason="inkex < 1.2 is not supported")
 
 class RegmarkTest(InsertRegmarkTest):
     source_file = "plus_with_duplicate.svg"

--- a/test/test_render_silhouette_regmark.py
+++ b/test/test_render_silhouette_regmark.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# coding=utf-8
+
+from render_silhouette_regmarks import InsertRegmark
+from inkex import BoundingBox
+from inkex.tester import TestCase
+
+
+class InsertRegmarkTest(TestCase):
+    """Tests for Inkscape Extensions"""
+
+    effect_class = InsertRegmark
+
+    def setUp(self):
+        self.e = self.effect_class()
+
+
+class RegmarkTest(InsertRegmarkTest):
+    source_file = "plus_with_duplicate.svg"
+
+    def test_regmarks(self):
+        self.e.parse_arguments([self.data_file(self.source_file), "--reglength=300"])
+        self.e.load_raw()
+        self.e.effect()
+
+        """Ensure top-left regmark"""
+        self.assertEqual(
+            self.e.svg.getElementById('regmark-tl').tostring(),
+            b'<rect x="10.0" y="10.0" width="5" height="5" style="fill:black"/>'
+        )
+
+        """Ensure top-right regmark"""
+        self.assertEqual(
+            self.e.svg.getElementById('regmark-tr').bounding_box(),
+            BoundingBox((390.0, 410.0),(10.0, 30.0))
+        )
+
+        """Ensure x distance"""
+        transform = self.e.svg.getElementById('regmark-tr').composed_transform()
+        self.assertEqual(
+            self.e.svg.unit_to_viewport(
+                    (self.e.svg.getElementById('regmark-tr').bounding_box(transform).x.maximum
+                    - self.e.svg.getElementById('regmark-bl').bounding_box(transform).x.minimum),
+                "mm"),
+            400
+        )
+
+        """Ensure y distance"""
+        transform = self.e.svg.getElementById('regmark-tr').composed_transform()
+        self.assertEqual(
+            self.e.svg.unit_to_viewport(
+                    (self.e.svg.getElementById('regmark-bl').bounding_box(transform).y.maximum
+                    - self.e.svg.getElementById('regmark-tr').bounding_box(transform).y.minimum),
+                "mm"),
+            300
+        )


### PR DESCRIPTION
Found [miLORD1337](https://github.com/miLORD1337) post in https://github.com/fablabnbg/inkscape-silhouette/issues/79 where he was proposing his work.

His code is GPLed and looks suitable for integration into this extension for convenience. For user experience, I've made the width and length parameter optional so that the user only needs to care about the spacing from edge of the document (we can generally assume that the document would be the print size (e.g. A4)... if that's not the case then the user can still override that value anyway.

Next thing we could do is update the reg mark page in the main script to also make these same parameter optional as well.

https://github.com/miLORD1337/silhouette-regmarks

![image](https://github.com/fablabnbg/inkscape-silhouette/assets/827793/0881b72a-027f-44a3-8277-db907f06ae19)
