### PR TITLE
feat: Multi Action Register Once

### DIFF
--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -270,6 +270,13 @@ class SendtoSilhouette(EffectExtension):
         pars.add_argument("--force_hardware",
                 dest = "force_hardware", default = None,
                 help = "Override hardware model of cutting device.")
+        # For Multi-Action
+        pars.add_argument("--skip_init",
+                dest = "skip_init", type = Boolean, default = False,
+                help = "Skip any setup, such as regmark searching (for Multi-Action).")
+        pars.add_argument("--skip_reset",
+                dest = "skip_reset", type = Boolean, default = False,
+                help = "Skip resetting to home at the end (for Multi-Action).")
         # Can't set up the log here because arguments have not yet been parsed;
         # defer that to the top of the effect() method, which is where all
         # of the real activity happens.
@@ -741,7 +748,8 @@ class SendtoSilhouette(EffectExtension):
                 sw_clipping=self.options.sw_clipping,
                 bladediameter=self.options.bladediameter,
                 pressure=self.options.pressure,
-                speed=self.options.speed)
+                speed=self.options.speed,
+                skip_init=self.options.skip_init)
 
         if self.options.autocrop:
             # this takes much longer, if we have a complext drawing
@@ -757,7 +765,9 @@ class SendtoSilhouette(EffectExtension):
                     regwidth=self.reg_width,
                     reglength=self.reg_length,
                     regoriginx=self.reg_origin_X,
-                    regoriginy=self.reg_origin_Y)
+                    regoriginy=self.reg_origin_Y,
+                    skip_init=self.options.skip_init,
+                    skip_reset=self.options.skip_reset)
 
             if len(bbox["bbox"].keys()):
                     self.report(
@@ -779,7 +789,9 @@ class SendtoSilhouette(EffectExtension):
             regwidth=self.reg_width,
             reglength=self.reg_length,
             regoriginx=self.reg_origin_X,
-            regoriginy=self.reg_origin_Y)
+            regoriginy=self.reg_origin_Y,
+            skip_init=self.options.skip_init,
+            skip_reset=self.options.skip_reset)
         if len(bbox["bbox"].keys()) == 0:
             self.report("empty page?", 'error')
         else:

--- a/silhouette/ColorSeparation.py
+++ b/silhouette/ColorSeparation.py
@@ -1,6 +1,8 @@
 import os
 import pickle
 
+from silhouette.Dialog import Dialog
+
 class ColorSeparation:
     """Keep sendto_silhouette settings on a per-color basis"""
     def __init__(self, *args, **kwargs):
@@ -71,7 +73,7 @@ class ColorSeparation:
             message.append("%d colors from the preset were not used." % len(extra_colors))
 
         if message and not silent:
-            Dialog.info(self, "Colors in the preset and this SVG did not match fully. " + " ".join(message))
+            Dialog.info(None, "Colors in the preset and this SVG did not match fully. " + " ".join(message))
 
     def generate_actions(self, default_actions):
         actions = []

--- a/silhouette/Dialog.py
+++ b/silhouette/Dialog.py
@@ -1,8 +1,7 @@
-import wx
-from wx.lib.agw import genericmessagedialog as gmd
-
 class Dialog:
     def confirm(parent, question, caption = 'Silhouette Multiple Actions'):
+        import wx
+        from wx.lib.agw import genericmessagedialog as gmd
         dlg = wx.MessageDialog(parent, question, caption, wx.YES_NO | wx.ICON_QUESTION)
         result = dlg.ShowModal() == wx.ID_YES
         dlg.Destroy()
@@ -10,6 +9,7 @@ class Dialog:
 
     def info(parent, message, extended = '',
                     caption = 'Silhouette Multiple Actions',):
+        from wx.lib.agw import genericmessagedialog as gmd
         dlg = gmd.GenericMessageDialog(
             parent, message, caption, wrap=1000,
             agwStyle=wx.OK | wx.ICON_INFORMATION | gmd.GMD_USE_AQUABUTTONS)

--- a/silhouette_multi.inx
+++ b/silhouette_multi.inx
@@ -12,7 +12,7 @@
     <vbox>
       <label>For normal use you may leave these options unchecked.</label>
       <param name="dry_run" type="bool" gui-text="Dry run: only show commands">false</param>
-      <param name="register_once" type="bool" gui-text="Skip reading registration marks after the first action">true</param>
+      <param name="register_once" type="bool" gui-text="Skip reading registration marks after the first action">false</param>
       <param name="block" type="bool" gui-text="Wait for cutter to finish before returning to Inkscape">false</param>
       <param name="verbose" type="bool" gui-text="Verbose output">false</param>
     </vbox>

--- a/silhouette_multi.inx
+++ b/silhouette_multi.inx
@@ -12,6 +12,7 @@
     <vbox>
       <label>For normal use you may leave these options unchecked.</label>
       <param name="dry_run" type="bool" gui-text="Dry run: only show commands">false</param>
+      <param name="register_once" type="bool" gui-text="Skip reading registration marks after the first action">true</param>
       <param name="block" type="bool" gui-text="Wait for cutter to finish before returning to Inkscape">false</param>
       <param name="verbose" type="bool" gui-text="Verbose output">false</param>
     </vbox>

--- a/silhouette_multi.py
+++ b/silhouette_multi.py
@@ -74,7 +74,7 @@ class SilhouetteMulti(EffectExtension):
             help="Enable verbose logging")
         pars.add_argument(
             "--register_once", dest="register_once", type=Boolean,
-            default=True,
+            default=False,
             help="Skip reading registration marks after the first action")
 
     def get_style(self, element):


### PR DESCRIPTION
Adds an option (default true) to the Multi-Action dialog to skip registration mark reading for all actions after the first action. Only the registration mark settings for the first action are used; registration mark settings for all other actions are ignored.

This has only been tested on a Cameo 4.

Closes https://github.com/fablabnbg/inkscape-silhouette/issues/250.