### PR TITLE
Fix method object is not iterable in Silhouette Multi

### DIFF
--- a/silhouette/MultiFrame.py
+++ b/silhouette/MultiFrame.py
@@ -382,7 +382,7 @@ class MultiFrame(wx.Frame):
 
     def run(self, event):
         self.save_color_settings()
-        actions = self.colsep.generate_actions(self.notebook.get_defaults)
+        actions = self.colsep.generate_actions(self.notebook.get_defaults())
         if actions:
             if not self.options.dry_run:
                 if not Dialog.confirm(None, "About to perform %d actions, continue?" % len(actions)):


### PR DESCRIPTION
My first time trying Multi mode gave me the error below. This patch corrects the error.

Traceback (most recent call last):
  File "/home/selah/jonh/.config/inkscape/extensions/silhouette/MultiFrame.py", line 395, in run
    self.run_callback(actions)
  File "/home/selah/jonh/.config/inkscape/extensions/silhouette_multi.py", line 202, in run_multi
    commands = self.format_commands(actions)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/selah/jonh/.config/inkscape/extensions/silhouette_multi.py", line 189, in format_commands
    command += " " + self.format_args(settings)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/selah/jonh/.config/inkscape/extensions/silhouette_multi.py", line 177, in format_args
    return " ".join(("--%s=%s" % (k, v) for k, v in args))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'method' object is not iterable