### PR TITLE
fix: add forgotten import wx

### DIFF
--- a/silhouette/Dialog.py
+++ b/silhouette/Dialog.py
@@ -9,6 +9,7 @@ class Dialog:
 
     def info(parent, message, extended = '',
                     caption = 'Silhouette Multiple Actions',):
+        import wx
         from wx.lib.agw import genericmessagedialog as gmd
         dlg = gmd.GenericMessageDialog(
             parent, message, caption, wrap=1000,


### PR DESCRIPTION
Overlooked an `import wx` when making the Dialog class lazy load wx. It has now been added to Dialog.info.