### PR TITLE
fix: remove call to missing function with unblock_inkscape

### DIFF
--- a/silhouette/MultiFrame.py
+++ b/silhouette/MultiFrame.py
@@ -296,8 +296,6 @@ class MultiFrame(wx.Frame):
         # end wxGlade
 
     def wrapup(self):
-        if self.options.unblock_inkscape:
-            show_log_as_dialog(self)
         self.Close()
 
     def close(self, event):


### PR DESCRIPTION
Fixes #213. Multi Action now works without blocking Inkscape.

A call to a nonexistent function `show_log_as_dialog` was previously being made if `unblock_inkscape` was true, which caused Multi Action to fail when not blocking Inkscape. Removing this call allows Multi Action to work properly without blocking Inkscape.