### PR TITLE
Add device info for Cameo 5 Plus (15" model)

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -149,6 +149,7 @@ Minimal Traveling (no reverse): Like fully optimized but respect original orient
 	<option translatable="no" value="Silhouette_Cameo4_Plus">Silhouette Cameo 4 Plus</option>
 	<option translatable="no" value="Silhouette_Cameo4_Pro">Silhouette Cameo 4 Pro</option>
 	<option translatable="no" value="Silhouette_Cameo5">Silhouette Cameo 5</option>									
+	<option translatable="no" value="Silhouette_Cameo5_Plus">Silhouette Cameo 5 Plus</option>									
 	<option translatable="no" value="Craft_Robo_CC200-20">Craft Robo CC200-20</option>
 	<option translatable="no" value="Craft_Robo_CC300-20">Craft Robo CC300-20</option>
 	<option translatable="no" value="Silhouette_SD_1">Silhouette SD 1</option>

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -134,6 +134,7 @@ PRODUCT_ID_SILHOUETTE_CAMEO4 =  0x1137
 PRODUCT_ID_SILHOUETTE_CAMEO4PLUS = 0x1138
 PRODUCT_ID_SILHOUETTE_CAMEO4PRO = 0x1139
 PRODUCT_ID_SILHOUETTE_CAMEO5 =  0x1140                                      
+PRODUCT_ID_SILHOUETTE_CAMEO5PLUS =  0x1141                                      
 PRODUCT_ID_SILHOUETTE_PORTRAIT = 0x1123
 PRODUCT_ID_SILHOUETTE_PORTRAIT2 = 0x1132
 PRODUCT_ID_SILHOUETTE_PORTRAIT3 = 0x113a
@@ -143,6 +144,7 @@ PRODUCT_LINE_CAMEO4 = [
   PRODUCT_ID_SILHOUETTE_CAMEO4PLUS,
   PRODUCT_ID_SILHOUETTE_CAMEO4PRO,
   PRODUCT_ID_SILHOUETTE_CAMEO5,  #Given the similarities between Cameo 4 and Cameo 5, I added Cameo 5 to this list                                       
+  PRODUCT_ID_SILHOUETTE_CAMEO5PLUS,  #Given the similarities between Cameo 4 and Cameo 5, I added Cameo 5 to this list                                       
   PRODUCT_ID_SILHOUETTE_PORTRAIT3,
 ]
 
@@ -227,7 +229,10 @@ DEVICE = [
    { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO5, 'name': 'Silhouette_Cameo5',
    # Took these settings from Cameo 4, haven't noticed any performance issues.
    #added extra margin space to experiment with the software cross-cutting feature
-   'width_mm':  330.2, 'length_mm': 3000, 'margin_left_mm':-6.0, 'margin_top_mm':0.0, 'regmark': True },                    
+   'width_mm':  330.2, 'length_mm': 3000, 'margin_left_mm': -6.0, 'margin_top_mm': 0.0, 'regmark': True },  
+   { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO5PLUS, 'name': 'Silhouette_Cameo5_Plus',
+   # Took these settings from Cameo 4 Plus, haven't noticed any performance issues.
+   'width_mm':  372, 'length_mm': 3000, 'margin_left_mm': 0.0, 'margin_top_mm': 0.0, 'regmark': True },                    
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_CC200_20, 'name': 'Craft_Robo_CC200-20',
    'width_mm':  200, 'length_mm': 1000, 'regmark': True },
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_CC300_20, 'name': 'Craft_Robo_CC300-20' },


### PR DESCRIPTION
Just added the device_id and it's relevant options. 
The device worked fine before this commit though, didn't test it very thoroughly though
This seems to have fixed an issue I had while selecting to use one tool or the other (before it just used Tool 1 no matter which one was selected, now it works as expected)