### PR TITLE
Update sendto_silhouette.inx for inputs order to reflect preset order

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -57,8 +57,8 @@
         <option value="137">[P=30,S=10,D=1] Vellum Bristol 57-67 lbs (145g)</option>
         <option value="138">[P=30,S=10,D=1] Writing Paper 24-70 lbs (105g)</option>
       </param>
-      <param name="speed" type="int" min="0" max="30" gui-text="Speed">0</param>
       <param name="pressure" type="int" min="0" max="33" gui-text="Pressure">0</param>
+      <param name="speed" type="int" min="0" max="30" gui-text="Speed">0</param>
       <param name="depth" type="int" min="-1" max="10" gui-text="Blade Depth (for AutoBlade)">-1</param>
       <label indent="2">Use speed=0, pressure=0, depth=-1 to take the media defaults. Pressure values of 19 or more could trigger the trackenhancing feature, which means a movement along the full media height before start. Beware.</label>
       <param name="preview" type="bool" gui-text="Preview: show cut pattern before sending">true</param>

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -60,7 +60,7 @@
       <param name="pressure" type="int" min="0" max="33" gui-text="Pressure">0</param>
       <param name="speed" type="int" min="0" max="30" gui-text="Speed">0</param>
       <param name="depth" type="int" min="-1" max="10" gui-text="Blade Depth (for AutoBlade)">-1</param>
-      <label indent="2">Use speed=0, pressure=0, depth=-1 to take the media defaults. Pressure values of 19 or more could trigger the trackenhancing feature, which means a movement along the full media height before start. Beware.</label>
+      <label indent="2">Use pressure=0, speed=0, depth=-1 to take the media defaults. Pressure values of 19 or more could trigger the trackenhancing feature, which means a movement along the full media height before start. Beware.</label>
       <param name="preview" type="bool" gui-text="Preview: show cut pattern before sending">true</param>
       <label indent="2">Note that for Preview to operate, the `matplotlib' package for Python must be installed.</label>
     </page>


### PR DESCRIPTION
As discussed in [this issue](https://github.com/fablabnbg/inkscape-silhouette/issues/322)

Changed Speed/Pressure/Depth inputs order to Pressure/Speed/Depth to reflect media preset's hint text order.