### PR TITLE
Added missing regmarks scripts copy to osx bash script

### DIFF
--- a/install_osx.py
+++ b/install_osx.py
@@ -17,6 +17,7 @@ prerequisites = ["cssselect", "xmltodict", "lxml", "pyusb", "libusb1", "numpy"]
 extensions_dir = os.path.join(os.path.expanduser("~"), "Library","Application Support","org.inkscape.Inkscape","config","inkscape","extensions")
 extension_files = ["sendto_silhouette.inx", "sendto_silhouette.py",
                    "silhouette_multi.inx",  "silhouette_multi.py",
+                   "render_silhouette_regmarks.inx", "render_silhouette_regmarks.py",
                    "silhouette"]
 
 


### PR DESCRIPTION
Basically in macos there is no copy of regmarks scripts while installing the package.
Both files `"render_silhouette_regmarks.inx"` and `"render_silhouette_regmarks.py"` needs to be copied on install in order to fix missing render tab: https://github.com/fablabnbg/inkscape-silhouette/issues/279#issue-2016831816