### PR TITLE
added udev-rules for cameo5

### DIFF
--- a/silhouette-udev.rules
+++ b/silhouette-udev.rules
@@ -1,4 +1,5 @@
-ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1139", MODE="666", ENV{silhouette_cameo4pro}="yes", GOTO="end"
+ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1140", MODE="666", ENV{silhouette_cameo5}="yes", GOTO="end"
+ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1139", MODE="666", ENV{silhouette_cameo4pro}="yes"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1138", MODE="666", ENV{silhouette_cameo4plus}="yes"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1137", MODE="666", ENV{silhouette_cameo4}="yes"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="112f", MODE="666", ENV{silhouette_cameo3}="yes"
@@ -14,7 +15,8 @@ ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="110a", MODE="666", ENV{craftrobo_cc2
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="111a", MODE="666", ENV{craftrobo_cc300_20}="yes"
 LABEL="end"
 
-ENV{silhouette_cameo4pro}=="yes",  RUN="/lib/udev/silhouette-udev-notify.sh", GOTO="very_end"
+ENV{silhouette_cameo5}=="yes",     RUN="/lib/udev/silhouette-udev-notify.sh", GOTO="very_end"
+ENV{silhouette_cameo4pro}=="yes",  RUN="/lib/udev/silhouette-udev-notify.sh"
 ENV{silhouette_cameo4plus}=="yes", RUN="/lib/udev/silhouette-udev-notify.sh"
 ENV{silhouette_cameo4}=="yes",     RUN="/lib/udev/silhouette-udev-notify.sh"
 ENV{silhouette_cameo3}=="yes",     RUN="/lib/udev/silhouette-udev-notify.sh"


### PR DESCRIPTION
don't really know why labels are needed here, but I kept it that way it was, that the label is appended to the most recent line, and models appear to be sorted by manuf. dat, so i added the cameo5 on top of each section. 
However it is recognized without issues by the inkscape-plugin with these udev-changes .

lsusb of the cameo5: 
```
Bus 007 Device 013: ID 0b4d:1140 Graphtec America, Inc. 
```