### PR TITLE
Add Cameo 5 Alpha support

### DIFF
--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -58,7 +58,7 @@
         <option value="137">[P=30,S=10,D=1] Vellum Bristol 57-67 lbs (145g)</option>
         <option value="138">[P=30,S=10,D=1] Writing Paper 24-70 lbs (105g)</option>
       </param>
-      <param name="pressure" type="int" min="0" max="33" gui-text="Pressure">0</param>
+      <param name="pressure" type="int" min="0" max="40" gui-text="Pressure">0</param>
       <param name="speed" type="int" min="0" max="30" gui-text="Speed">0</param>
       <param name="depth" type="int" min="-1" max="10" gui-text="Blade Depth (for AutoBlade)">-1</param>
       <label indent="2">Use pressure=0, speed=0, depth=-1 to take the media defaults. Pressure values of 19 or more could trigger the trackenhancing feature, which means a movement along the full media height before start. Beware.</label>
@@ -86,6 +86,8 @@
       <label indent="2">The document contains printed registration marks</label>
       <param name="regsearch" type="bool" gui-text="Search for the registration marks automatically">false</param>
       <label indent="2">Search for the registration marks automatically. Seems on some devices there is another mode, where you can set the references manually.</label>
+      <param name="quadregmarks" type="bool" gui-text="Use 4 registration marks">false</param>
+      <label indent="2">On the Cameo 5α, registration marks in 4 corners can be used. Has no effect on other devices.</label>
       <param name="regoriginx" type="float" min="0.0" max="10000" gui-text="Position of regmark from document left [mm]">10</param>
       <param name="regoriginy" type="float" min="0.0" max="10000" gui-text="Position of regmark from document top [mm]">10</param>
       <label indent="2">Distance of the registration mark edges</label>

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -244,6 +244,9 @@ class SendtoSilhouette(EffectExtension):
         pars.add_argument("--regsearch",
                 dest = "regsearch", type = Boolean, default = False,
                 help="Search for the registration marks.")
+        pars.add_argument("-Q", "--quadregmarks",
+                dest = "quadregmarks", type = Boolean, default = False,
+                help="Use 4 registration marks.")
         pars.add_argument("-X", "--reg-x", "--regwidth",
                 type = float, dest = "regwidth", default = 0.0, help="X mark to mark distance [mm]")
         pars.add_argument("-Y", "--reg-y", "--reglength",
@@ -765,6 +768,7 @@ class SendtoSilhouette(EffectExtension):
                     endposition="start",
                     regmark=self.options.regmark,
                     regsearch=self.options.regsearch,
+                    quadregmarks=self.options.quadregmarks,
                     regwidth=self.reg_width,
                     reglength=self.reg_length,
                     regoriginx=self.reg_origin_X,
@@ -789,6 +793,7 @@ class SendtoSilhouette(EffectExtension):
             end_paper_offset=self.options.end_offset,
             regmark=self.options.regmark,
             regsearch=self.options.regsearch,
+            quadregmarks=self.options.quadregmarks,
             regwidth=self.reg_width,
             reglength=self.reg_length,
             regoriginx=self.reg_origin_X,

--- a/silhouette-udev.rules
+++ b/silhouette-udev.rules
@@ -1,3 +1,4 @@
+ATTRS{idVendor}=="3844", ATTRS{idProduct}=="0001", MODE="666", ENV{silhouette_cameo5alpha}="yes", GOTO="end"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1140", MODE="666", ENV{silhouette_cameo5}="yes", GOTO="end"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1139", MODE="666", ENV{silhouette_cameo4pro}="yes"
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="1138", MODE="666", ENV{silhouette_cameo4plus}="yes"
@@ -15,6 +16,7 @@ ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="110a", MODE="666", ENV{craftrobo_cc2
 ATTRS{idVendor}=="0b4d", ATTRS{idProduct}=="111a", MODE="666", ENV{craftrobo_cc300_20}="yes"
 LABEL="end"
 
+ENV{silhouette_cameo5alpha}=="yes",     RUN="/lib/udev/silhouette-udev-notify.sh", GOTO="very_end"
 ENV{silhouette_cameo5}=="yes",     RUN="/lib/udev/silhouette-udev-notify.sh", GOTO="very_end"
 ENV{silhouette_cameo4pro}=="yes",  RUN="/lib/udev/silhouette-udev-notify.sh"
 ENV{silhouette_cameo4plus}=="yes", RUN="/lib/udev/silhouette-udev-notify.sh"


### PR DESCRIPTION
This PR adds Cameo 5α support, including support for the new 4 corner registration marks system for cutting.

Some interesting observations:
* The vendor ID changed to 0x0b4d, and the product ID is 0x0001.
* The command for the 4 corner regmarks is `TB124` with the same parameters as the old command (`TB123`).
* The Cameo 5α is still compatible with the old 3 registration marks system if the command from older generations for regmarks is used, despite it not being possible to do so from Silhouette Studio.
* The pressure maximum is 40.

Not implemented:
* Regmarks at intervals along the page.
* Power tools.
* New regmark generation for printing.