### PR TITLE
Fix Externally Managed Environment - Update OS X Install Script - Uses Inkscape's Python

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: Run Python tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -61,7 +62,7 @@ jobs:
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
         brew install --cask inkscape
-        pip install libusb1
+        brew install libusb
     - name: 🗖 install Inkscape (fixed)
       if: ${{ matrix.os == 'windows-latest' && startsWith(matrix.inkscape-version, '1.') }}
       run: |
@@ -73,13 +74,22 @@ jobs:
     - name: inkscape version
       run: |
         inkscape --version || echo "inkscape not found"
-    - name: install requirements
+    - name: install requirements (macos)
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        ./install_osx.sh
+        . "$HOME/.local/share/venvs/inkscape/bin/activate"
+        pip install pytest
+    - name: install requirements (non-macos)
+      if: ${{ matrix.os != 'macos-latest' }}
       run: |
         python -m pip install --break-system-packages --upgrade pip
         pip install -r requirements.txt
         pip install pytest
     - name: test
+      shell: bash
       env:
         PYTHONWARNINGS: default
       run: |
-        pytest -s -vv test
+       [[ -e "$HOME/.local/share/venvs/inkscape/bin/activate" ]] && source "$HOME/.local/share/venvs/inkscape/bin/activate"
+       pytest -s -vv test

--- a/README.md
+++ b/README.md
@@ -145,14 +145,15 @@ Finally, load the file with:
 <summary>Click to get steps</summary>
 
 * Install prerequisites:
-  * install homebrew http://brew.sh/
+  * Install homebrew http://brew.sh/
   * `brew install libusb`
-  * `brew install python3`
+  * Install Inkscape
+      * Either with homebrew: `brew install inkscape`
+      * Or manually from their [website](https://inkscape.org/)
 * Install the extension:
-  * `./install_osx.py`
-  * Add brew python for user extensions in `~/Library/Application Support/org.inkscape.Inkscape/config/inkscape/preferences.xml` on `<group id="extensions" python-interpreter="/..." />`. For details on selecting a specific interpreter version see [Inkscape Wiki - Extension Interpreters](https://inkscape.gitlab.io/extensions/documentation/authors/interpreters.html):
-    * `python-interpreter="/usr/local/bin/python3"` on X86 platform
-    * `python-interpreter="/opt/homebrew/bin/python3"` on ARM platform (Apple Silicon)
+  * `./install_osx.sh`
+  * Add the suggested python interpreter for user extensions in `~/Library/Application Support/org.inkscape.Inkscape/config/inkscape/preferences.xml` on `<group id="extensions" python-interpreter="/..." />`. For details on selecting a specific interpreter version see [Inkscape Wiki - Extension Interpreters](https://inkscape.gitlab.io/extensions/documentation/authors/interpreters.html):
+    * e.g. `python-interpreter="/Users/username/.local/share/venvs/inkscape/bin/python3"`
 
 </details>
 

--- a/install_osx.sh
+++ b/install_osx.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+VENV="$HOME/.local/share/venvs/inkscape"
+
+INK_PY=$(\
+      find /Applications/Inkscape.app \
+      -type f \
+      -path "*/Python.framework/Versions/*/bin/python3*" \
+      -not -path "*/Python.framework/Versions/*/bin/python3*-*" \
+      | sort -V | tail -n1 \
+  )
+
+if [ -x "$INK_PY" ]; then
+    echo "Using Inkscape Python: $INK_PY"
+else
+    echo "Could not find Inkscape Python. Got: '$INK_PY'"
+    echo "Bailing out."
+    exit -1
+fi
+
+echo "Removing old venv (if any)..."
+rm -rf "$VENV"
+mkdir -p "$(dirname "$VENV")"
+
+echo "Creating new venv (inherits Inkscape's packages)..."
+"$INK_PY" -m venv --system-site-packages "$VENV"
+
+echo "Activating and chaining up to second stage install"
+source "$VENV/bin/activate"
+python -m ensurepip -U || true
+pip install --upgrade pip
+
+./install_osx_stage2.py

--- a/install_osx_stage2.py
+++ b/install_osx_stage2.py
@@ -13,7 +13,7 @@ import os, sys, shutil, logging, subprocess
 
 logger = logging.getLogger(__name__)
 
-prerequisites = ["cssselect", "xmltodict", "lxml", "pyusb", "libusb1", "numpy"]
+prerequisites = ["cssselect", "xmltodict", "lxml", "pyusb", "libusb1", "matplotlib", "wxPython"]
 extensions_dir = os.path.join(os.path.expanduser("~"), "Library","Application Support","org.inkscape.Inkscape","config","inkscape","extensions")
 extension_files = ["sendto_silhouette.inx", "sendto_silhouette.py",
                    "silhouette_multi.inx",  "silhouette_multi.py",
@@ -41,7 +41,7 @@ def install_inkscape_silhouette():
         install_extension()
         check_libusb()
         logger.info("inkscape_silhouette extension install ended")
-        logger.info("Don't forget to add 'python-interpreter=\"%s\"' to your extension preference file.", subprocess.check_output(["which", "python3"]).decode("utf-8").replace("\n", ""))
+        logger.info("\x1b[31;20mDon't forget\x1b[0m to add 'python-interpreter=\"%s\"' to your extension preference file.", subprocess.check_output(["which", "python3"]).decode("utf-8").replace("\n", ""))
     except Exception as ex:
         logger.warning("inkscape_silhouette install was unsuccessful. Please check previous messages for the cause. Details: %s", ex)
 
@@ -116,6 +116,10 @@ if __name__ == "__main__":
     log_formatter = logging.Formatter('%(levelname)s: %(message)s')
     log_console.setFormatter(log_formatter)
     logger.addHandler(log_console)
+
+    if sys.prefix == sys.base_prefix:
+        logger.critical("The installer should be running in a virtual environment. \x1b[31;20mPlease run install_osx.sh\x1b[0m. Bailing out.")
+        sys.exit(-1)
 
     # run installer
     install_inkscape_silhouette()


### PR DESCRIPTION
This pull request fixes the homebrew error "Externally Managed Environment" on recent OS X versions. Rather than using homebrew's python and having to re-install/duplicate all packages provided by Inkscape, it creates a venv that is a strict superset of the Inkscape bundled python and installs additional dependencies safely onto that.

Additionnaly it updates the readme and adds safeguards on the scripts to avoid direct calling of the python install script. 