### PR TITLE
Add support for Silhouette Cameo Pro Mark 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This extension should work with the following devices:
 * Craft Robo CC300-20
 * Silhouette SD 1
 * Silhouette SD 2
+
 **Note for Cameo Pro Mark 2:** Basic cutting and movement are supported, but Registration Mark sensing (Print & Cut) is currently disabled and under development.
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ This extension should work with the following devices:
 * Silhouette Cameo 4 Pro
 * Silhouette Cameo 5
 * Silhouette Cameo 5 Plus
+* Silhouette Cameo Pro Mark 2
 * Silhouette Curio (partial success confirmed in #36)
 * Craft Robo CC200-20
 * Craft Robo CC300-20
 * Silhouette SD 1
 * Silhouette SD 2
-
+**Note for Cameo Pro Mark 2:** Basic cutting and movement are supported, but Registration Mark sensing (Print & Cut) is currently disabled and under development.
 ---
 
 ## Installation

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -154,7 +154,7 @@ Minimal Traveling (no reverse): Like fully optimized but respect original orient
 	<option translatable="no" value="Silhouette_Cameo4_Pro">Silhouette Cameo 4 Pro</option>
 	<option translatable="no" value="Silhouette_Cameo5">Silhouette Cameo 5</option>									
 	<option translatable="no" value="Silhouette_Cameo5_Plus">Silhouette Cameo 5 Plus</option>									
-                <option translatable="no" value="Silhouette_Cameo_Pro_Mark2">Silhouette Cameo Pro Mark 2</option>
+    <option translatable="no" value="Silhouette_Cameo_Pro_Mark2">Silhouette Cameo Pro Mark 2</option>
 	<option translatable="no" value="Craft_Robo_CC200-20">Craft Robo CC200-20</option>
 	<option translatable="no" value="Craft_Robo_CC300-20">Craft Robo CC300-20</option>
 	<option translatable="no" value="Silhouette_SD_1">Silhouette SD 1</option>

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -154,6 +154,7 @@ Minimal Traveling (no reverse): Like fully optimized but respect original orient
 	<option translatable="no" value="Silhouette_Cameo4_Pro">Silhouette Cameo 4 Pro</option>
 	<option translatable="no" value="Silhouette_Cameo5">Silhouette Cameo 5</option>									
 	<option translatable="no" value="Silhouette_Cameo5_Plus">Silhouette Cameo 5 Plus</option>									
+                <option translatable="no" value="Silhouette_Cameo_Pro_Mark2">Silhouette Cameo Pro Mark 2</option>
 	<option translatable="no" value="Craft_Robo_CC200-20">Craft Robo CC200-20</option>
 	<option translatable="no" value="Craft_Robo_CC300-20">Craft Robo CC300-20</option>
 	<option translatable="no" value="Silhouette_SD_1">Silhouette SD 1</option>

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -208,7 +208,7 @@ DEVICE = [
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT4, 'name': 'Silhouette_Portrait4',
    'width_mm':  216, 'length_mm': 18290, 'regmark': True },
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2, 'name': 'Silhouette_Cameo_Pro_Mark2',
-             'width_mm': 609, 'length_mm': 18290, 'regmark': False},
+   'width_mm': 609, 'length_mm': 18290, 'regmark': False },
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO, 'name': 'Silhouette_Cameo',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -208,7 +208,7 @@ DEVICE = [
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT4, 'name': 'Silhouette_Portrait4',
    'width_mm':  216, 'length_mm': 18290, 'regmark': True },
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2, 'name': 'Silhouette_Cameo_Pro_Mark2',
-             'width_mm': 609, 'length_mm': 18290, 'regmark': True},
+             'width_mm': 609, 'length_mm': 18290, 'regmark': False},
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO, 'name': 'Silhouette_Cameo',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -144,6 +144,8 @@ PRODUCT_ID_SILHOUETTE_PORTRAIT = 0x1123
 PRODUCT_ID_SILHOUETTE_PORTRAIT2 = 0x1132
 PRODUCT_ID_SILHOUETTE_PORTRAIT3 = 0x113a
 PRODUCT_ID_SILHOUETTE_PORTRAIT4 = 0x113f
+PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2 = 0x1146
+
 
 PRODUCT_LINE_CAMEO4 = [
   PRODUCT_ID_SILHOUETTE_CAMEO4,
@@ -154,6 +156,7 @@ PRODUCT_LINE_CAMEO4 = [
   PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA,
   PRODUCT_ID_SILHOUETTE_PORTRAIT3,
   PRODUCT_ID_SILHOUETTE_PORTRAIT4,
+          PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2,
 ]
 
 PRODUCT_LINE_CAMEO3_ON = PRODUCT_LINE_CAMEO4 + [PRODUCT_ID_SILHOUETTE_CAMEO3]
@@ -203,7 +206,9 @@ DEVICE = [
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT3, 'name': 'Silhouette_Portrait3',
    'width_mm':  203, 'length_mm': 18290, 'regmark': True },
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT4, 'name': 'Silhouette_Portrait4',
-   'width_mm':  216, 'length_mm': 18290, 'regmark': True },
+   'width_mm':  216, 'length_mm': 18290, 'regmark': True }
+      { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2, 'name': 'Silhouette_Cameo_Pro_Mark2',
+             'width_mm': 609, 'length_mm': 18290, 'regmark': True},,
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO, 'name': 'Silhouette_Cameo',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -156,7 +156,7 @@ PRODUCT_LINE_CAMEO4 = [
   PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA,
   PRODUCT_ID_SILHOUETTE_PORTRAIT3,
   PRODUCT_ID_SILHOUETTE_PORTRAIT4,
-          PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2,
+  PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2,
 ]
 
 PRODUCT_LINE_CAMEO3_ON = PRODUCT_LINE_CAMEO4 + [PRODUCT_ID_SILHOUETTE_CAMEO3]
@@ -206,9 +206,9 @@ DEVICE = [
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT3, 'name': 'Silhouette_Portrait3',
    'width_mm':  203, 'length_mm': 18290, 'regmark': True },
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT4, 'name': 'Silhouette_Portrait4',
-   'width_mm':  216, 'length_mm': 18290, 'regmark': True }
-      { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2, 'name': 'Silhouette_Cameo_Pro_Mark2',
-             'width_mm': 609, 'length_mm': 18290, 'regmark': True},,
+   'width_mm':  216, 'length_mm': 18290, 'regmark': True },
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2, 'name': 'Silhouette_Cameo_Pro_Mark2',
+             'width_mm': 609, 'length_mm': 18290, 'regmark': True},
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO, 'name': 'Silhouette_Cameo',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!


### PR DESCRIPTION
This pull request adds support for the Silhouette Cameo Pro Mark 2.

### Current Status / Known Issues
- Verified: Basic cutting and movement are verified for this model.
- - Experimental: Registration Mark sensing (Print & Cut) is currently experimental and not fully operational for this specific model yet. Help from other users with this hardware would be appreciated to finalize the TB command sequence.
### Changes included:
- Added PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2 constant with ID 0x1146.
- - Added the device to the PRODUCT_LINE_CAMEO4 list.
- - Added the device definition to the DEVICES list in silhouette/Graphtec.py with standard dimensions (609mm width).
This addresses the support requested in Issue #362.