### PR TITLE
fix: Translation issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ install: mo # Install is used by dist or use this with this command `sudo make i
 	cp -r silhouette $(DEST)
 	install -m 755 *silhouette*.py $(DEST)
 	install -m 644 *.inx $(DEST)
-	cp -r locale $(LOCALE)
+	cp -r locale/* $(LOCALE) #Fixed to copy only the files and subfolders, not the entire folder
 	mkdir -p $(UDEV)/rules.d
 	install -m 644 -T silhouette-udev.rules $(UDEV)/rules.d/40-silhouette-udev.rules
 	install -m 644 silhouette-icon.png $(UDEV)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This extension should work with the following devices:
 
 ## Installation
 
-### Ubuntu
+### Ubuntu and Debian
 
 <details>
 <summary>Click to get steps</summary>


### PR DESCRIPTION
## Problem
 The `install` target copies the `locale` directory itself into `$(LOCALE)` (`/usr/share/locale`), resulting in a duplicated path:
```
/usr/share/locale/locale/<lang>/LC_MESSAGES/inkscape-silhouette.mo
```

This causes translations to not be found at runtime.

## Fix

Change `cp -r locale $(LOCALE)` to `cp -r locale/* $(LOCALE)` so that only the **contents** of the `locale` folder are copied into the destination, producing the correct path:
```
/usr/share/locale/<lang/LC_MESSAGES/inkscape-silhouette.mo
```

## Change

-`Makefile` line 50: `cp -r locale $(LOCALE)` to `cp -r locale/* $(LOCALE)`
-`README.md` line 38: updated Distribution