### PR TITLE
feat: Add full registration marks (print-and-cut) support for Silhouette Cameo Pro MK-II

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ This extension should work with the following devices:
 * Silhouette Cameo 4 Pro
 * Silhouette Cameo 5
 * Silhouette Cameo 5 Plus
-* Silhouette Cameo Pro Mark 2
+* Silhouette Cameo Pro MK-II (working confirmed)
 * Silhouette Curio (partial success confirmed in #36)
 * Craft Robo CC200-20
 * Craft Robo CC300-20
 * Silhouette SD 1
 * Silhouette SD 2
 
-**Note for Cameo Pro Mark 2:** Basic cutting and movement are supported, but Registration Mark sensing (Print & Cut) is currently disabled and under development.
+**Note for Cameo Pro MK-II:** Full cutting, movement, and automatic four-corner Registration Mark sensing (Print & Cut) are fully supported and verified.
 ---
 
 ## Installation

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -154,7 +154,7 @@ Minimal Traveling (no reverse): Like fully optimized but respect original orient
 	<option translatable="no" value="Silhouette_Cameo4_Pro">Silhouette Cameo 4 Pro</option>
 	<option translatable="no" value="Silhouette_Cameo5">Silhouette Cameo 5</option>									
 	<option translatable="no" value="Silhouette_Cameo5_Plus">Silhouette Cameo 5 Plus</option>									
-    <option translatable="no" value="Silhouette_Cameo_Pro_Mark2">Silhouette Cameo Pro Mark 2</option>
+    <option translatable="no" value="Silhouette_Cameo_Pro_MK-II">Silhouette Cameo Pro MK-II</option>
 	<option translatable="no" value="Craft_Robo_CC200-20">Craft Robo CC200-20</option>
 	<option translatable="no" value="Craft_Robo_CC300-20">Craft Robo CC300-20</option>
 	<option translatable="no" value="Silhouette_SD_1">Silhouette SD 1</option>

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -144,7 +144,7 @@ PRODUCT_ID_SILHOUETTE_PORTRAIT = 0x1123
 PRODUCT_ID_SILHOUETTE_PORTRAIT2 = 0x1132
 PRODUCT_ID_SILHOUETTE_PORTRAIT3 = 0x113a
 PRODUCT_ID_SILHOUETTE_PORTRAIT4 = 0x113f
-PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2 = 0x1146
+PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MK_II = 0x1146
 
 
 PRODUCT_LINE_CAMEO4 = [
@@ -156,7 +156,7 @@ PRODUCT_LINE_CAMEO4 = [
   PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA,
   PRODUCT_ID_SILHOUETTE_PORTRAIT3,
   PRODUCT_ID_SILHOUETTE_PORTRAIT4,
-  PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2,
+  PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MK_II,
 ]
 
 PRODUCT_LINE_CAMEO3_ON = PRODUCT_LINE_CAMEO4 + [PRODUCT_ID_SILHOUETTE_CAMEO3]
@@ -207,8 +207,8 @@ DEVICE = [
    'width_mm':  203, 'length_mm': 18290, 'regmark': True },
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_PORTRAIT4, 'name': 'Silhouette_Portrait4',
    'width_mm':  216, 'length_mm': 18290, 'regmark': True },
- { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MARK2, 'name': 'Silhouette_Cameo_Pro_Mark2',
-   'width_mm': 609, 'length_mm': 18290, 'regmark': False },
+ { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MK_II, 'name': 'Silhouette_Cameo_Pro_MK-II',
+   'width_mm': 609, 'length_mm': 18290, 'regmark': True, 'quadregmarks': True },
  { 'vendor_id': VENDOR_ID_GRAPHTEC, 'product_id': PRODUCT_ID_SILHOUETTE_CAMEO, 'name': 'Silhouette_Cameo',
    # margin_top_mm is just for safety when moving backwards with thin media
    # margin_left_mm is a physical limit, but is relative to width_mm!


### PR DESCRIPTION
This PR adds full print-and-cut (registration marks) support for the **Silhouette Cameo Pro MK-II** (USB Product ID 0x1146), and updates its name across the codebase to match the official manufacturer marketing designation.

### Key Changes

### 1. Renamed Model to Official Naming:

-  Updated references from **Silhouette Cameo Pro Mark 2** to **Silhouette Cameo Pro MK-II** in _s_ilhouette/Graphtec.py__ and _sendto_silhouette.inx_ to align with Silhouette America's official naming.

- Renamed the product ID constant to _PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MK_II_ for consistency.

### 2. Enabled Registration Marks & Quadregmarks:

- Set _'regmark': True_ and _'quadregmarks': True_ in the _DEVICE_ list configuration for this model inside Graphtec.py.

- Unlocking _quadregmarks_ instructs the driver to issue the modern _TB124_ command (four-corner registration mark search) instead of the legacy _TB123_ command, which is exactly what the new MK-II firmware expects (matching the Silhouette Studio v1.5 protocol).

**Physical Verification & Testing**

This (including this description) was made with the help of AI, but these changes have been physically tested and verified on a real **Silhouette Cameo Pro MK-II** hardware unit with the following results:

- **Connection / Handshake**: Flawlessly recognized and connected via PyUSB.

- **Optical Registration Scan**: The plotter successfully scans all 4 printed registration marks autonomously using the _TB124_ routine.

- **AutoBlade Calibration**: The carriage properly performs the physical tapping/depth adjustment routine before cutting.

- **Cut Trajectory Accuracy**: Successfully processed complex SVG curves in standard ASCII _D_ mode with perfect alignment.

- **Maestro Reset & End Position**: Media parks and resets correctly at completion without throwing any firmware errors.

This is a clean integration that officially enables the complete print-and-cut workflow for all users of this 24-inch plotter. We kept the changes minimal, safe, and fully aligned with the existing codebase standards.

Thank you for reviewing!