### PR TITLE
feat: add 4-corner regmark generation for, e.g., Cameo 5a

### DIFF
--- a/render_silhouette_regmarks.inx
+++ b/render_silhouette_regmarks.inx
@@ -3,6 +3,10 @@
   <name>Silhouette Regmarks</name>
   <id>com.github.fablabnbg.inkscape-silhouette.silhouette-regmarks</id>
   <dependency type="executable" location="inx">render_silhouette_regmarks.py</dependency>
+  <param name="regstyle" type="optiongroup" appearance="combo" gui-text="Registration mark style">
+    <option value="standard">Standard (square + two L-marks)</option>
+    <option value="four_corner">4 corner (four L-marks, e.g. Cameo 5 Alpha)</option>
+  </param>
   <param name="regoriginx" type="float" min="10.0" max="10000" gui-text="Position of regmark from document left [mm]">10</param>
   <param name="regoriginy" type="float" min="10.0" max="10000" gui-text="Position of regmark from document top [mm]">10</param>
   <label indent="2">Spacing of the registration mark edges</label>

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -56,8 +56,13 @@ REGMARK_LAYER_ID = 'regmark'
 REGMARK_TOP_LEFT_ID = 'regmark-tl'
 REGMARK_TOP_RIGHT_ID = 'regmark-tr'
 REGMARK_BOTTOM_LEFT_ID = 'regmark-bl'
+REGMARK_BOTTOM_RIGHT_ID = 'regmark-br'
 REGMARK_SAFE_AREA_ID = 'regmark-safe-area'
 REGMARK_NOTES_ID = 'regmark-notes'
+
+# Registration mark styles
+REGSTYLE_STANDARD = 'standard'
+REGSTYLE_FOUR_CORNER = 'four_corner'
 
 REG_SQUARE_MM = 5
 REG_LINE_MM = 20
@@ -79,13 +84,25 @@ class InsertRegmark(EffectExtension):
 		pars.add_argument("-Y", "--reg-y", "--reglength", type = float, dest = "reglength",  default = 0.0, help="Y mark to mark distance [mm]")
 		pars.add_argument("--rego-x",  "--regoriginx",    type = float, dest = "regoriginx", default = 10.0,  help="X mark origin from left [mm]")
 		pars.add_argument("--rego-y", "--regoriginy",     type = float, dest = "regoriginy", default = 10.0,  help="X mark origin from top [mm]")
+		pars.add_argument("--regstyle", dest = "regstyle", type = str, default = REGSTYLE_STANDARD, help="registration mark style (standard or four_corner)")
 		pars.add_argument("--verbose", dest = "verbose",  type = Boolean, default = False, help="enable log messages")
+
+	def l_mark(self, corner_x, corner_y, h_dir, v_dir, mark_id, line_width):
+		# Build an L-shaped corner mark: a horizontal and a vertical arm meeting
+		# at (corner_x, corner_y). h_dir/v_dir (+1 or -1) point the arms inward.
+		path = [
+			(corner_x + h_dir * REG_LINE_MM, corner_y),
+			(corner_x, corner_y),
+			(corner_x, corner_y + v_dir * REG_LINE_MM),
+		]
+		return PathElement.new(path="M"+str(path), id=mark_id, style=f"fill:none; stroke:black; stroke-width:{line_width};")
 
 	def effect(self):
 		reg_origin_X = self.options.regoriginx
 		reg_origin_Y = self.options.regoriginy
 		reg_width = self.options.regwidth or self.svg.to_dimensional(self.svg.viewport_width, "mm") - reg_origin_X * 2
 		reg_length = self.options.reglength or self.svg.to_dimensional(self.svg.viewport_height, "mm") - reg_origin_Y * 2
+		reg_style = self.options.regstyle
 
 		if self.options.verbose == True:
 			self.msg(gettext("[INFO]: page width ")+str(self.svg.to_dimensional(self.svg.viewport_width, "mm")))
@@ -107,18 +124,25 @@ class InsertRegmark(EffectExtension):
 		regmark_layer = Layer.new(REGMARK_LAYERNAME, id=REGMARK_LAYER_ID)
 		regmark_layer.transform = Transform(scale=mm_to_user_unit)
 
-		# Create square in top left corner
-		regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id=REGMARK_TOP_LEFT_ID, style='fill:black;'))
-
-		# Create horizontal and vertical lines in group for top right corner
 		top_right_x = reg_origin_X+reg_width
-		top_right_path = [(top_right_x-REG_LINE_MM,reg_origin_Y), (top_right_x,reg_origin_Y), (top_right_x,reg_origin_Y + REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path="M"+str(top_right_path), id=REGMARK_TOP_RIGHT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM};"))
-
-		# Create horizontal and vertical lines in group for bottom left corner
 		bottom_left_y = reg_origin_Y+reg_length
-		bottom_left_path = [(reg_origin_X+REG_LINE_MM,bottom_left_y), (reg_origin_X,bottom_left_y), (reg_origin_X,bottom_left_y - REG_LINE_MM)]
-		regmark_layer.append(PathElement.new(path="M"+str(bottom_left_path), id=REGMARK_BOTTOM_LEFT_ID, style=f"fill:none; stroke:black; stroke-width:{REG_MARK_LINE_WIDTH_MM};"))
+
+		# Top left corner: a filled square for the standard style, or an L-shaped
+		# mark for the four-corner style (which uses four matching corner marks).
+		if reg_style == REGSTYLE_FOUR_CORNER:
+			regmark_layer.append(self.l_mark(reg_origin_X, reg_origin_Y, +1, +1, REGMARK_TOP_LEFT_ID, REG_MARK_LINE_WIDTH_MM))
+		else:
+			regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id=REGMARK_TOP_LEFT_ID, style='fill:black;'))
+
+		# Create horizontal and vertical lines for top right corner
+		regmark_layer.append(self.l_mark(top_right_x, reg_origin_Y, -1, +1, REGMARK_TOP_RIGHT_ID, REG_MARK_LINE_WIDTH_MM))
+
+		# Create horizontal and vertical lines for bottom left corner
+		regmark_layer.append(self.l_mark(reg_origin_X, bottom_left_y, +1, -1, REGMARK_BOTTOM_LEFT_ID, REG_MARK_LINE_WIDTH_MM))
+
+		# The four-corner style additionally uses a fourth L-shaped mark in the bottom right corner
+		if reg_style == REGSTYLE_FOUR_CORNER:
+			regmark_layer.append(self.l_mark(top_right_x, bottom_left_y, -1, -1, REGMARK_BOTTOM_RIGHT_ID, REG_MARK_LINE_WIDTH_MM))
 
 		# Safe Area Marker #
 		# This draws the safe drawing area
@@ -126,6 +150,19 @@ class InsertRegmark(EffectExtension):
 		safearea_top_y = reg_origin_Y+REG_LINE_MM
 		safearea_right_x = reg_origin_X+reg_width-REG_LINE_MM
 		safearea_bottom_y = reg_origin_Y+reg_length-REG_LINE_MM
+		if reg_style == REGSTYLE_FOUR_CORNER:
+			# Notch the safe area around the fourth (bottom right) mark, just like
+			# the other three corners, so its stroke is not partially covered.
+			bottom_right_corner = [
+				(safearea_right_x+REG_SAFE_AREA_MM,safearea_bottom_y),
+				(safearea_right_x,safearea_bottom_y),
+				(safearea_right_x,safearea_bottom_y+REG_SAFE_AREA_MM),
+			]
+		else:
+			# Standard style has no bottom right mark, so keep the corner square.
+			bottom_right_corner = [
+				(safearea_right_x+REG_SAFE_AREA_MM,safearea_bottom_y+REG_SAFE_AREA_MM),
+			]
 		safe_area_points = [
 			(safearea_left_x-REG_SAFE_AREA_MM,safearea_top_y),
 			(safearea_left_x,safearea_top_y),
@@ -133,7 +170,7 @@ class InsertRegmark(EffectExtension):
 			(safearea_right_x,safearea_top_y-REG_SAFE_AREA_MM),
 			(safearea_right_x,safearea_top_y),
 			(safearea_right_x+REG_SAFE_AREA_MM,safearea_top_y),
-			(safearea_right_x+REG_SAFE_AREA_MM,safearea_bottom_y+REG_SAFE_AREA_MM),
+		] + bottom_right_corner + [
 			(safearea_left_x,safearea_bottom_y+REG_SAFE_AREA_MM),
 			(safearea_left_x,safearea_bottom_y),
 			(safearea_left_x-REG_SAFE_AREA_MM,safearea_bottom_y),

--- a/test/test_render_silhouette_regmark.py
+++ b/test/test_render_silhouette_regmark.py
@@ -15,6 +15,7 @@ REGMARK_LAYER_ID = 'regmark'
 REGMARK_TOP_LEFT_ID = 'regmark-tl'
 REGMARK_TOP_RIGHT_ID = 'regmark-tr'
 REGMARK_BOTTOM_LEFT_ID = 'regmark-bl'
+REGMARK_BOTTOM_RIGHT_ID = 'regmark-br'
 REGMARK_SAFE_AREA_ID = 'regmark-safe-area'
 REGMARK_NOTES_ID = 'regmark-notes'
 
@@ -59,6 +60,67 @@ class RegmarkTest(InsertRegmarkTest):
         )
 
         """Ensure y distance"""
+        self.assertEqual(
+            self.e.svg.unit_to_viewport(
+                    (self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform=True).y.maximum
+                    - self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform=True).y.minimum),
+                "mm"),
+            300
+        )
+
+    def test_standard_has_no_bottom_right_regmark(self):
+        """The standard style only draws three marks (square + two L-marks)"""
+        self.e.parse_arguments([self.data_file(self.source_file), "--reglength=300"])
+        self.e.load_raw()
+        self.e.effect()
+        self.e.clean_up()
+
+        self.assertIsNone(self.e.svg.getElementById(REGMARK_BOTTOM_RIGHT_ID))
+
+
+class FourCornerRegmarkTest(InsertRegmarkTest):
+    source_file = "plus_with_duplicate.svg"
+
+    def setUp(self):
+        super().setUp()
+        self.e.parse_arguments(
+            [self.data_file(self.source_file), "--reglength=300", "--regstyle=four_corner"]
+        )
+        self.e.load_raw()
+        self.e.effect()
+        self.e.clean_up()
+
+    def test_top_left_is_l_mark(self):
+        """In four-corner style the top-left mark is an L-shaped path, not a filled square"""
+        top_left = self.e.svg.getElementById(REGMARK_TOP_LEFT_ID)
+        self.assertEqual(top_left.tag_name, "path")
+        self.assertEqual(
+            top_left.bounding_box(),
+            BoundingBox((10.0, 30.0), (10.0, 30.0))
+        )
+
+    def test_bottom_right_regmark(self):
+        """Four-corner style adds a fourth L-shaped mark in the bottom-right corner"""
+        bottom_right = self.e.svg.getElementById(REGMARK_BOTTOM_RIGHT_ID)
+        self.assertIsNotNone(bottom_right)
+        self.assertEqual(bottom_right.tag_name, "path")
+        self.assertEqual(
+            bottom_right.bounding_box(),
+            BoundingBox((390.0, 410.0), (290.0, 310.0))
+        )
+
+    def test_x_distance(self):
+        """Ensure x distance between right and left marks"""
+        self.assertEqual(
+            self.e.svg.unit_to_viewport(
+                    (self.e.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform=True).x.maximum
+                    - self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform=True).x.minimum),
+                "mm"),
+            400
+        )
+
+    def test_y_distance(self):
+        """Ensure y distance between top and bottom marks"""
         self.assertEqual(
             self.e.svg.unit_to_viewport(
                     (self.e.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform=True).y.maximum


### PR DESCRIPTION
## Why This Change
The cut settings has support for sending to the cutter with Cameo 5a / 4-corner regmarks, but the regmark generation plugin can't generate 4 corner registration marks for these devices.

## What Changed
- Add new option to registration mark generator plugin, `--regstyle`, that accepts either `standard` (current behavior, default) or `four_corner` (new 4 corner behavior).
- Edit generation logic to generate 4 corner marks (upper left mark is also "L shaped" instead of a small square)
- Refactored L shaped mark generation code into `l_mark` function.
- Add new test for 4 corner marks

## How I tested it
- New/existing tests pass
- In Inkscape, 4 corner marks generate as expected when using new setting (existing settings are unchanged): 
<img width="524" height="655" alt="{A0353907-FAC1-4350-9F9D-1A4DDF4BF652}" src="https://github.com/user-attachments/assets/f2efcb87-cd3d-46a2-b84b-edc59bf2cd81" />
