### PR TITLE
feat: add bluetooth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ Refer to the [userguide instructions](./USERGUIDE.md) for further details.
 
 Run `sendto_silhouette.py --help` for information on CLI usage.
 
+### Bluetooth
+
+Bluetooth-capable cutters (Cameo 3 and newer, Portrait 2 and newer, Curio 2, and similar) can be driven wirelessly instead of over USB. Pair the cutter with your operating system first, then use the **Bluetooth** tab in the GUI (or `--bluetooth_scan` / `--bluetooth_addr` on the CLI). See [Connecting over Bluetooth](./USERGUIDE.md#connecting-over-bluetooth) for step-by-step instructions.
+
+Bluetooth is currently supported on **Linux and Windows only**; macOS lacks Python RFCOMM socket support, so USB must be used there for now (contributions to add macOS Bluetooth are welcome).
+
 ---
 
 ## Templates
@@ -288,6 +294,9 @@ This fails on win32/64 with 'module has no attribute 'version info' which then c
 * reverse toggle options, to cut the opposite direction. This might also be
   helpful with mat-free cutting via multipass.
 * honors hidden layers.
+* Bluetooth support. Cutters with Bluetooth can be driven wirelessly instead of
+  over USB, after pairing with the operating system. See
+  [Connecting over Bluetooth](./USERGUIDE.md#connecting-over-bluetooth).
 
 ## Misfeatures of InkCut that we do not 'feature'
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -83,6 +83,46 @@ For enhanced precision, you may have to set an offset on **X-Offset** and/or **Y
 
 ---
 
+## Connecting over Bluetooth
+
+Bluetooth-capable cutters (Cameo 3 and newer, Portrait 2 and newer, Curio 2, and similar) can be driven wirelessly instead of over USB.
+
+**Before you start:** pair the cutter with your operating system's own Bluetooth settings first, exactly as you would any other Bluetooth device. The extension does not do the pairing for you; it only connects to a cutter your computer has already paired. Make sure the cutter is powered on and in range.
+
+**Steps:**
+
+1. Open **Extensions &rarr; Export &rarr; Send to Silhouette** and switch to the **Bluetooth** tab.
+2. Find your cutter's address: tick **Scan for Bluetooth devices (list, then stop)** and click **Apply**. A dialog lists each paired Silhouette cutter with its address, name, and detected model, then stops without cutting. For example:
+   ```
+   Found 1 Bluetooth Silhouette cutter(s):
+       00:1B:41:33:44:55   CAMEO 5 ALPHA-000000   [Silhouette_Cameo5_Alpha]
+
+   Copy the address of the cutter you want into the 'Bluetooth MAC address' field.
+   ```
+3. Copy the address of the cutter you want into the **Bluetooth MAC address** field, and untick the scan box.
+4. Set your plot parameters as usual and click **Apply** to cut over Bluetooth.
+
+**Notes:**
+
+- Leave the **Bluetooth MAC address** field empty to use USB (the default).
+- You must enter the address explicitly. There is intentionally no "connect to whatever is nearby" option, so a stranger's cutter that comes into range — or the wrong one, if you own several — can never be selected by accident.
+- The cutter model is detected automatically from its firmware. If it is not recognised, set it with **Override cutter model** on the **Log and Dump** tab.
+- **Bluetooth Classic vs. BLE (important):** some (most?) cutters advertise themselves *twice* — once as a **Bluetooth Classic** device and once as a **Bluetooth Low Energy (BLE)** device, often with the same or a nearly identical name. This extension communicates over Bluetooth Classic (the RFCOMM serial profile), so you must pair the **Classic** entry. If you pair only the BLE entry, the cutter will not show up in the scan and a connection will fail. The scan deliberately lists only the Classic, RFCOMM-connectable address, so if two entries appear in your OS Bluetooth settings, pair the one that lets the cutter appear in the scan.
+- The scan lists devices your operating system has already paired. If your cutter is missing, pair it in your OS Bluetooth settings (as a Classic device — see above), confirm it is on and in range, and scan again. On Linux the scan uses `bluetoothctl` (BlueZ); installing PyBluez (`pip install pybluez`) additionally enables a live inquiry.
+- **macOS is not currently supported.** Python's Bluetooth RFCOMM sockets are only available on Linux and Windows, so the Bluetooth features described here do not work on macOS. USB still works normally on macOS. Adding macOS Bluetooth support — for example via a `/dev/cu.*` serial port or Apple's IOBluetooth framework — would be a very welcome contribution; see [CONTRIBUTING](./CONTRIBUTING.md).
+
+**From the command line** the same is available without the dialog:
+
+```sh
+# list paired Bluetooth cutters and their addresses, then stop
+sendto_silhouette.py --bluetooth_scan=True yourfile.svg
+
+# cut over Bluetooth using an explicit address
+sendto_silhouette.py --bluetooth_addr=00:1B:41:33:44:55 yourfile.svg
+```
+
+---
+
 ## Design Tips
 
 ### Getting an outline of a vector object

--- a/po/de.po
+++ b/po/de.po
@@ -639,3 +639,20 @@ msgstr ""
 #: sendto_silhouette.py:909
 msgid "Warning: unable to draw <{str(t[-1])}> object,"
 msgstr "Warnung: Zeichnen des <{str(t[-1])}> Objekts nicht möglich,"
+
+
+#: sendto_silhouette.inx:169
+msgid "Bluetooth MAC address"
+msgstr ""
+
+#: sendto_silhouette.inx:170
+msgid "Scan for Bluetooth devices (list, then stop)"
+msgstr ""
+
+#: sendto_silhouette.inx:171
+msgid "Connect over Bluetooth instead of USB (e.g. 00:1B:41:33:44:55); tick the scan above to discover the address. Leave empty for USB; pair the cutter with your operating system first."
+msgstr ""
+
+#: sendto_silhouette.inx:172
+msgid "The cutter model is detected from its firmware. If it is not recognised, set it with 'Override cutter model' on the Log and Dump tab."
+msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -641,18 +641,22 @@ msgid "Warning: unable to draw <{str(t[-1])}> object,"
 msgstr "Warnung: Zeichnen des <{str(t[-1])}> Objekts nicht möglich,"
 
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:169
 msgid "Bluetooth MAC address"
-msgstr ""
+msgstr "Bluetooth-MAC-Adresse"
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:170
 msgid "Scan for Bluetooth devices (list, then stop)"
-msgstr ""
+msgstr "Nach Bluetooth-Geräten suchen (auflisten, dann stoppen)"
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:171
 msgid "Connect over Bluetooth instead of USB (e.g. 00:1B:41:33:44:55); tick the scan above to discover the address. Leave empty for USB; pair the cutter with your operating system first."
-msgstr ""
+msgstr "Über Bluetooth statt USB verbinden (z. B. 00:1B:41:33:44:55); den Scan oben anhaken, um die Adresse zu ermitteln. Für USB leer lassen; den Cutter zuerst mit dem Betriebssystem koppeln."
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:172
 msgid "The cutter model is detected from its firmware. If it is not recognised, set it with 'Override cutter model' on the Log and Dump tab."
-msgstr ""
+msgstr "Das Cutter-Modell wird aus seiner Firmware erkannt. Wird es nicht erkannt, stelle es mit 'Cutter-Model überschreiben' im Reiter 'Logging und Speicherauszug' ein."

--- a/po/fr.po
+++ b/po/fr.po
@@ -505,3 +505,19 @@ msgstr "Avertissement : impossible de dessiner les images bitmap ; veuillez d'ab
 msgid "Warning: unable to draw <{str(t[-1])}> object,"
 msgstr "Avertissement : impossible de dessiner l'objet <{str(t[-1])}>,"
 
+
+#: sendto_silhouette.inx:169
+msgid "Bluetooth MAC address"
+msgstr ""
+
+#: sendto_silhouette.inx:170
+msgid "Scan for Bluetooth devices (list, then stop)"
+msgstr ""
+
+#: sendto_silhouette.inx:171
+msgid "Connect over Bluetooth instead of USB (e.g. 00:1B:41:33:44:55); tick the scan above to discover the address. Leave empty for USB; pair the cutter with your operating system first."
+msgstr ""
+
+#: sendto_silhouette.inx:172
+msgid "The cutter model is detected from its firmware. If it is not recognised, set it with 'Override cutter model' on the Log and Dump tab."
+msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -506,18 +506,22 @@ msgid "Warning: unable to draw <{str(t[-1])}> object,"
 msgstr "Avertissement : impossible de dessiner l'objet <{str(t[-1])}>,"
 
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:169
 msgid "Bluetooth MAC address"
-msgstr ""
+msgstr "Adresse MAC Bluetooth"
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:170
 msgid "Scan for Bluetooth devices (list, then stop)"
-msgstr ""
+msgstr "Rechercher les appareils Bluetooth (lister, puis arrêter)"
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:171
 msgid "Connect over Bluetooth instead of USB (e.g. 00:1B:41:33:44:55); tick the scan above to discover the address. Leave empty for USB; pair the cutter with your operating system first."
-msgstr ""
+msgstr "Se connecter via Bluetooth au lieu de l'USB (par ex. 00:1B:41:33:44:55) ; cochez la recherche ci-dessus pour découvrir l'adresse. Laissez vide pour l'USB ; appairez d'abord la découpeuse avec votre système d'exploitation."
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:172
 msgid "The cutter model is detected from its firmware. If it is not recognised, set it with 'Override cutter model' on the Log and Dump tab."
-msgstr ""
+msgstr "Le modèle de découpeuse est détecté à partir de son micrologiciel. S'il n'est pas reconnu, définissez-le avec 'Ignorer le modèle de découpeuse' dans l'onglet 'Journal et vidage'."

--- a/po/inkscape-silhouette.pot
+++ b/po/inkscape-silhouette.pot
@@ -525,3 +525,20 @@ msgstr ""
 #: sendto_silhouette.py:909
 msgid "Warning: unable to draw <{str(t[-1])}> object,"
 msgstr ""
+
+
+#: sendto_silhouette.inx:169
+msgid "Bluetooth MAC address"
+msgstr ""
+
+#: sendto_silhouette.inx:170
+msgid "Scan for Bluetooth devices (list, then stop)"
+msgstr ""
+
+#: sendto_silhouette.inx:171
+msgid "Connect over Bluetooth instead of USB (e.g. 00:1B:41:33:44:55); tick the scan above to discover the address. Leave empty for USB; pair the cutter with your operating system first."
+msgstr ""
+
+#: sendto_silhouette.inx:172
+msgid "The cutter model is detected from its firmware. If it is not recognised, set it with 'Override cutter model' on the Log and Dump tab."
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -649,3 +649,20 @@ msgstr ""
 #: sendto_silhouette.py:909
 msgid "Warning: unable to draw <{str(t[-1])}> object,"
 msgstr "Aviso: não é possível desenhar o objeto <{str(t[-1])}>,"
+
+
+#: sendto_silhouette.inx:169
+msgid "Bluetooth MAC address"
+msgstr ""
+
+#: sendto_silhouette.inx:170
+msgid "Scan for Bluetooth devices (list, then stop)"
+msgstr ""
+
+#: sendto_silhouette.inx:171
+msgid "Connect over Bluetooth instead of USB (e.g. 00:1B:41:33:44:55); tick the scan above to discover the address. Leave empty for USB; pair the cutter with your operating system first."
+msgstr ""
+
+#: sendto_silhouette.inx:172
+msgid "The cutter model is detected from its firmware. If it is not recognised, set it with 'Override cutter model' on the Log and Dump tab."
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -651,18 +651,22 @@ msgid "Warning: unable to draw <{str(t[-1])}> object,"
 msgstr "Aviso: não é possível desenhar o objeto <{str(t[-1])}>,"
 
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:169
 msgid "Bluetooth MAC address"
-msgstr ""
+msgstr "Endereço MAC Bluetooth"
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:170
 msgid "Scan for Bluetooth devices (list, then stop)"
-msgstr ""
+msgstr "Procurar dispositivos Bluetooth (listar e depois parar)"
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:171
 msgid "Connect over Bluetooth instead of USB (e.g. 00:1B:41:33:44:55); tick the scan above to discover the address. Leave empty for USB; pair the cutter with your operating system first."
-msgstr ""
+msgstr "Conectar via Bluetooth em vez de USB (por ex. 00:1B:41:33:44:55); marque a busca acima para descobrir o endereço. Deixe vazio para USB; primeiro emparelhe a ferramenta de corte com o seu sistema operacional."
 
+# Machine-generated translation; needs review.
 #: sendto_silhouette.inx:172
 msgid "The cutter model is detected from its firmware. If it is not recognised, set it with 'Override cutter model' on the Log and Dump tab."
-msgstr ""
+msgstr "O modelo da ferramenta de corte é detectado a partir de seu firmware. Se não for reconhecido, defina-o com 'Sobrepor modelo da ferramenta de corte' na aba 'Registro e Despejo'."

--- a/sendto_silhouette.inx
+++ b/sendto_silhouette.inx
@@ -165,6 +165,13 @@ Minimal Traveling (no reverse): Like fully optimized but respect original orient
       <label indent="2">Using any setting other than `as detected' is not recommended except when performing a dry run.</label>
     </page>
 
+    <page name='bluetooth' gui-text='Bluetooth'>
+      <param name="bluetooth_addr" type="string" gui-text="Bluetooth MAC address"></param>
+      <param name="bluetooth_scan" type="bool" gui-text="Scan for Bluetooth devices (list, then stop)">false</param>
+      <label indent="2">Connect over Bluetooth instead of USB (e.g. 00:1B:41:33:44:55); tick the scan above to discover the address. Leave empty for USB; pair the cutter with your operating system first.</label>
+      <label indent="2">The cutter model is detected from its firmware. If it is not recognised, set it with 'Override cutter model' on the Log and Dump tab.</label>
+    </page>
+
     <page name='blade' gui-text='Blade Setting'>
       <label xml:space="preserve">
 Always use the least amount of blade possible.

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -324,13 +324,8 @@ class SendtoSilhouette(EffectExtension):
 
 
     def report_bluetooth_scan(self):
-        """Discover paired/reachable Bluetooth cutters and report them.
-
-        Inkscape cannot fill a dropdown at runtime, so this surfaces the
-        discovered devices (with their addresses and detected models) in the
-        extension's message dialog; the user copies the address of the intended
-        cutter into the 'Bluetooth MAC address' field.
-        """
+        """List paired Bluetooth cutters (address, name, model) in the message
+        dialog for the user to copy an address from."""
         from silhouette.Transport import BluetoothTransport
         from silhouette.Graphtec import _match_bluetooth_hardware
 

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -273,6 +273,15 @@ class SendtoSilhouette(EffectExtension):
         pars.add_argument("--force_hardware",
                 dest = "force_hardware", default = None,
                 help = "Override hardware model of cutting device.")
+        pars.add_argument("--bluetooth_addr",
+                dest = "bluetooth_addr", default = None,
+                help = "Connect over Bluetooth to this MAC address (e.g. 00:1B:41:33:44:55) instead of USB. Use --bluetooth_scan to discover addresses.")
+        pars.add_argument("--bluetooth_channel",
+                dest = "bluetooth_channel", type = int, default = None,
+                help = "RFCOMM channel for the Bluetooth connection (default: standard channel).")
+        pars.add_argument("--bluetooth_scan",
+                dest = "bluetooth_scan", type = Boolean, default = False,
+                help = "List paired/reachable Bluetooth Silhouette cutters and their addresses, then stop.")
         # For Multi-Action
         pars.add_argument("--skip_init",
                 dest = "skip_init", type = Boolean, default = False,
@@ -312,6 +321,44 @@ class SendtoSilhouette(EffectExtension):
             # oops accidentally used an invalid level
             print(f"  ... WARNING: message issued at invalid level {level}",
                   file=sys.stderr)
+
+
+    def report_bluetooth_scan(self):
+        """Discover paired/reachable Bluetooth cutters and report them.
+
+        Inkscape cannot fill a dropdown at runtime, so this surfaces the
+        discovered devices (with their addresses and detected models) in the
+        extension's message dialog; the user copies the address of the intended
+        cutter into the 'Bluetooth MAC address' field.
+        """
+        from silhouette.Transport import BluetoothTransport
+        from silhouette.Graphtec import _match_bluetooth_hardware
+
+        if not BluetoothTransport.is_available():
+            self.report("Bluetooth is not supported by this Python build/platform.", 'error')
+            return
+        try:
+            # Filter to Silhouette cutters using Graphtec's model table, so
+            # there is no separate list of device names to keep in sync.
+            devices = BluetoothTransport.discover(
+                name_filter=lambda n: _match_bluetooth_hardware(n) is not None)
+        except Exception as e:
+            self.report("Bluetooth scan failed: %s" % e, 'error')
+            return
+        if not devices:
+            self.report("No paired Silhouette Bluetooth cutters found.\n"
+                        "Pair the cutter with your operating system first, then scan again.", 'error')
+            return
+
+        lines = ["Found %d Bluetooth Silhouette cutter(s):" % len(devices)]
+        for addr, name in devices:
+            hw = _match_bluetooth_hardware(name)
+            model = hw['name'] if hw else 'unknown model'
+            lines.append("    %s   %s   [%s]" % (addr, name, model))
+        lines.append("")
+        lines.append("Copy the address of the cutter you want into the "
+                     "'Bluetooth MAC address' field.")
+        self.report("\n".join(lines), 'error')
 
 
     def plotPath(self, path: Path):
@@ -646,6 +693,12 @@ class SendtoSilhouette(EffectExtension):
 
         self.logEnvironment()
 
+        # Bluetooth device scan: list cutters and stop, before doing any work
+        # that depends on the document geometry or a connected device.
+        if self.options.bluetooth_scan:
+            self.report_bluetooth_scan()
+            return
+
         # Registration Mark Selection/Calcuation
         self.sync_regmark_settings()
 
@@ -728,13 +781,18 @@ class SendtoSilhouette(EffectExtension):
             self.options.speed = None
         if self.options.depth == -1:
             self.options.depth = None
+        # An empty Bluetooth address means "use USB".
+        if not self.options.bluetooth_addr:
+            self.options.bluetooth_addr = None
 
         try:
             dev = SilhouetteCameo(log=self.log, progress_cb=self.writeProgress,
                                   cmdfile=self.cmdfile,
                                   inc_queries=self.options.inc_queries,
                                   dry_run=self.options.dry_run,
-                                  force_hardware=self.options.force_hardware)
+                                  force_hardware=self.options.force_hardware,
+                                  bluetooth_addr=self.options.bluetooth_addr,
+                                  bluetooth_channel=self.options.bluetooth_channel)
         except Exception as e:
             self.report(e, 'error')
             return

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -25,8 +25,11 @@
 
 import os
 import re
+import socket
 import sys
 import time
+
+from silhouette.Transport import USBTransport, BluetoothTransport
 
 usb_reset_needed = False  # https://github.com/fablabnbg/inkscape-silhouette/issues/10
 
@@ -265,6 +268,54 @@ DEVICE = [
 ]
 
 
+# Bluetooth cutters do not expose USB vendor/product ids. Instead they identify
+# themselves via the advertised BLE name and the firmware version query (FG),
+# e.g. "CAMEO 5 ALPHA V1.02". Map those model names to the USB product id so a
+# Bluetooth connection resolves to the same hardware definition (and therefore
+# the same command behaviour) as the equivalent USB device.
+#
+# Order matters: more specific names must come first so that e.g.
+# "CAMEO 5 ALPHA PLUS" is matched before "CAMEO 5 ALPHA" before "CAMEO 5".
+BLUETOOTH_NAME_TO_PRODUCT_ID = [
+  ("CAMEO 5 ALPHA PLUS", PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA_PLUS),
+  ("CAMEO 5 ALPHA",      PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA),
+  ("CAMEO 5 PLUS",       PRODUCT_ID_SILHOUETTE_CAMEO5PLUS),
+  ("CAMEO 5",            PRODUCT_ID_SILHOUETTE_CAMEO5),
+  ("CAMEO PRO MARK2",    PRODUCT_ID_SILHOUETTE_CAMEO_PRO_MK_II),
+  ("CAMEO 4 PLUS",       PRODUCT_ID_SILHOUETTE_CAMEO4PLUS),
+  ("CAMEO 4 PRO",        PRODUCT_ID_SILHOUETTE_CAMEO4PRO),
+  ("CAMEO 4",            PRODUCT_ID_SILHOUETTE_CAMEO4),
+  ("CAMEO3",             PRODUCT_ID_SILHOUETTE_CAMEO3),
+  ("PORTRAIT4",          PRODUCT_ID_SILHOUETTE_PORTRAIT4),
+  ("PORTRAIT3",          PRODUCT_ID_SILHOUETTE_PORTRAIT3),
+  ("PORTRAIT2",          PRODUCT_ID_SILHOUETTE_PORTRAIT2),
+]
+
+
+def _hardware_by_product_id(product_id):
+  """Return the DEVICE entry for a given USB product id, or None."""
+  for hardware in DEVICE:
+    if hardware.get('product_id') == product_id:
+      return hardware
+  return None
+
+
+def _match_bluetooth_hardware(model_string):
+  """Map an advertised BLE name / FG firmware response to a DEVICE entry.
+
+  Matching is case-insensitive and ignores the trailing firmware version, so
+  both "CAMEO 5 ALPHA" and "CAMEO 5 ALPHA V1.02" resolve to the same device.
+  Returns the DEVICE dict or None if no known model matches.
+  """
+  if not model_string:
+    return None
+  needle = model_string.strip().upper()
+  for name, product_id in BLUETOOTH_NAME_TO_PRODUCT_ID:
+    if needle.startswith(name) or name in needle:
+      return _hardware_by_product_id(product_id)
+  return None
+
+
 def _bbox_extend(bb, x, y):
     # The coordinate system origin is in the top lefthand corner.
     # Downwards and rightwards we count positive. Just like SVG or HPGL.
@@ -366,11 +417,18 @@ class SilhouetteCameoTool:
 
 class SilhouetteCameo:
   def __init__(self, log=sys.stderr, cmdfile=None, inc_queries=False,
-               dry_run=False, progress_cb=None, force_hardware=None):
+               dry_run=False, progress_cb=None, force_hardware=None,
+               bluetooth_addr=None, bluetooth_channel=None):
     """ This initializer simply finds the first known device.
         The default paper alignment is left hand side for devices with known width
         (currently Cameo and Portrait). Otherwise it is right hand side.
         Use setup() to specify your needs.
+
+        If bluetooth_addr is specified, the cutter is contacted over an RFCOMM
+        Bluetooth connection at that MAC address (e.g. "00:1B:41:33:44:55")
+        instead of being probed on USB. The model is then identified from the
+        firmware version query (or from force_hardware). bluetooth_channel
+        defaults to the standard RFCOMM channel used by these cutters.
 
         If cmdfile is specified, it is taken as a file-like object in which to
         record a transcript of all commands sent to the cutter. If inc_queries is
@@ -402,6 +460,42 @@ class SilhouetteCameo:
     if self.dry_run:
       print("Dry run specified; no commands will be sent to cutter.",
             file=self.log)
+
+    self.transport = None
+    self.mock_response = None
+    self.need_interface = False         # probably never needed, but harmful on some versions of usb.core
+
+    if bluetooth_addr is not None:
+      # Bluetooth: connect to the given MAC address instead of probing USB.
+      dev = None
+      self._connect_bluetooth(bluetooth_addr, bluetooth_channel)
+    else:
+      # USB: probe the known devices and wrap the result in a transport.
+      dev = self._find_usb_device()
+      if dev is not None:
+        self.transport = USBTransport(dev, need_interface=self.need_interface)
+
+    for hardware in DEVICE:
+      if hardware["name"] == force_hardware:
+        print("NOTE: Overriding device from", self.hardware.get('name','None'),
+              "to", hardware['name'], file=self.log)
+        self.hardware = hardware
+        break
+
+    self.dev = dev
+    self.regmark = False                # not yet implemented. See robocut/Plotter.cpp:446
+    if self.transport is None or 'width_mm' in self.hardware:
+      self.leftaligned = True
+    self.enable_sw_clipping = True
+    self.clip_fuzz = 0.05
+
+  def _find_usb_device(self):
+    """Probe the USB bus for a known Graphtec/Silhouette device.
+
+    Sets self.hardware, performs any platform specific device initialization
+    and returns the raw pyusb/libusb device object (or None when running as a
+    dry run with no device attached)."""
+    dev = None
 
     for hardware in DEVICE:
       try:
@@ -445,10 +539,11 @@ class SilhouetteCameo:
         dev = None
 
     if dev is None:
-      if dry_run:
+      if self.dry_run:
         print("No device detected; continuing dry run with dummy device",
               file=self.log)
         self.hardware = dict(name='Crashtest Dummy Device')
+        return None
       else:
         msg = ''
         try:
@@ -470,25 +565,24 @@ class SilhouetteCameo:
 
     print("%s found on usb bus=%d addr=%d" % (self.hardware['name'], dev_bus, dev_addr), file=self.log)
 
-    if dev is not None:
-      if sys_platform.startswith('win'):
-        print("device init under windows not implemented. Help adding code!", file=self.log)
+    if sys_platform.startswith('win'):
+      print("device init under windows not implemented. Help adding code!", file=self.log)
 
-      elif sys_platform.startswith('darwin'):
-        dev.claimInterface(0)
-        # usb_enpoint = 1
-        # dev.bulkWrite(usb_endpoint, data)
+    elif sys_platform.startswith('darwin'):
+      dev.claimInterface(0)
+      # usb_enpoint = 1
+      # dev.bulkWrite(usb_endpoint, data)
 
-      else:     # linux
-        try:
-          if dev.is_kernel_driver_active(0):
-            print("is_kernel_driver_active(0) returned nonzero", file=self.log)
-            if dev.detach_kernel_driver(0):
-              print("detach_kernel_driver(0) returned nonzero", file=self.log)
-        except usb.core.USBError as e:
-          print("usb.core.USBError:", e, file=self.log)
-          if e.errno == 13:
-            msg = """
+    else:     # linux
+      try:
+        if dev.is_kernel_driver_active(0):
+          print("is_kernel_driver_active(0) returned nonzero", file=self.log)
+          if dev.detach_kernel_driver(0):
+            print("detach_kernel_driver(0) returned nonzero", file=self.log)
+      except usb.core.USBError as e:
+        print("usb.core.USBError:", e, file=self.log)
+        if e.errno == 13:
+          msg = """
 If you are not running as root, this might be a udev issue.
 Try a file /etc/udev/rules.d/99-graphtec-silhouette.rules
 with the following example syntax:
@@ -497,43 +591,68 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="%04x", ATTR{idProduct}=="%04x", MODE="666"
 Then run 'sudo udevadm trigger' to load this file.
 
 Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.hardware['vendor_id'], self.hardware['product_id'])
-            print(msg, file=self.log)
-            print(msg, file=sys.stderr)
-          sys.exit(0)
+          print(msg, file=self.log)
+          print(msg, file=sys.stderr)
+        sys.exit(0)
 
-        if usb_reset_needed:
-          for i in range(5):
-            try:
-              dev.reset()
-              break
-            except usb.core.USBError as e:
-              print("reset failed: ", e, file=self.log)
-              print("retrying reset in 5 sec", file=self.log)
-              time.sleep(5)
+      if usb_reset_needed:
+        for i in range(5):
+          try:
+            dev.reset()
+            break
+          except usb.core.USBError as e:
+            print("reset failed: ", e, file=self.log)
+            print("retrying reset in 5 sec", file=self.log)
+            time.sleep(5)
 
-        try:
-          dev.set_configuration()
-          dev.set_interface_altsetting()      # Probably not really necessary.
-        except usb.core.USBError:
-          pass
+      try:
+        dev.set_configuration()
+        dev.set_interface_altsetting()      # Probably not really necessary.
+      except usb.core.USBError:
+        pass
 
-    for hardware in DEVICE:
-      if hardware["name"] == force_hardware:
-        print("NOTE: Overriding device from", self.hardware.get('name','None'),
-              "to", hardware['name'], file=self.log)
-        self.hardware = hardware
-        break
+    return dev
 
-    self.dev = dev
-    self.need_interface = False         # probably never needed, but harmful on some versions of usb.core
-    self.regmark = False                # not yet implemented. See robocut/Plotter.cpp:446
-    if self.dev is None or 'width_mm' in self.hardware:
-      self.leftaligned = True
-    self.enable_sw_clipping = True
-    self.clip_fuzz = 0.05
-    self.mock_response = None
+  def _connect_bluetooth(self, bluetooth_addr, bluetooth_channel):
+    """Open a Bluetooth RFCOMM connection and identify the cutter model.
+
+    Sets self.transport and self.hardware. The address must be explicit (use
+    the Bluetooth scan to discover it); the model is inferred from the firmware
+    version query (FG), or pass force_hardware to override it."""
+    try:
+      self.transport = BluetoothTransport.connect(bluetooth_addr, bluetooth_channel)
+    except Exception as e:
+      if self.dry_run:
+        print("Bluetooth connect to %s failed (%s); continuing dry run with dummy device"
+              % (bluetooth_addr, e), file=self.log)
+        self.transport = None
+        self.hardware = dict(name='Crashtest Dummy Device')
+        return
+      raise ValueError("Could not open Bluetooth connection to %s: %s" % (bluetooth_addr, e))
+
+    # Identify the model from the firmware version response, e.g. "CAMEO 5 ALPHA V1.02".
+    model = None
+    try:
+      model = self.get_version()
+    except Exception as e:
+      print("Bluetooth firmware version query failed: %s" % e, file=self.log)
+
+    hardware = _match_bluetooth_hardware(model)
+    if hardware is not None:
+      self.hardware = hardware
+      print("%s (firmware '%s') connected on %s"
+            % (self.hardware['name'], model, self.transport.location), file=self.log)
+    else:
+      self.hardware = { 'name': 'Unknown Bluetooth Graphtec device' }
+      if model:
+        self.hardware['name'] += " (%s)" % model.strip()
+      print("Connected to unrecognized Bluetooth device (firmware '%s') on %s;\n"
+            "use --force_hardware to select the model."
+            % (model, self.transport.location), file=self.log)
 
   def __del__(self, *args):
+    if getattr(self, 'transport', None) is not None:
+      self.transport.close()
     if self.commands:
       self.commands.close()
 
@@ -558,7 +677,7 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
 
     # If there is no device, the only thing we might need to do is mock
     # a response:
-    if self.dev is None:
+    if self.transport is None:
       if data in SilhouetteCameo.mock_responses:
         self.mock_response = SilhouetteCameo.mock_responses[data]
       return None
@@ -589,22 +708,13 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
           self.log.flush()
       chunk = data[o:o+chunksz]
       try:
-        if self.need_interface:
-          try:
-            r = self.dev.write(endpoint, chunk, interface=0, timeout=timeout)
-          except AttributeError:
-            r = self.dev.bulkWrite(endpoint, chunk, interface=0, timeout=timeout)
-        else:
-          try:
-            r = self.dev.write(endpoint, chunk, timeout=timeout)
-          except AttributeError:
-            r = self.dev.bulkWrite(endpoint, chunk, timeout=timeout)
+        r = self.transport.write_bytes(chunk, timeout)
       except TypeError as te:
         # write() got an unexpected keyword argument 'interface'
-        raise TypeError("Write Exception: %s, %s dev=%s" % (type(te), te, type(self.dev)))
+        raise TypeError("Write Exception: %s, %s transport=%s" % (type(te), te, type(self.transport)))
       except AttributeError as ae:
         # write() got an unexpected keyword argument 'interface'
-        raise TypeError("Write Exception: %s, %s dev=%s" % (type(ae), ae, type(self.dev)))
+        raise TypeError("Write Exception: %s, %s transport=%s" % (type(ae), ae, type(self.transport)))
 
       except Exception as e:
         # raise USBError(_str_error[ret], ret, _libusb_errno[ret])
@@ -675,20 +785,12 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     """Low level read method, returns response as bytes"""
     endpoint = 0x82
     data = None
-    if self.dev is None:
+    if self.transport is None:
       data = self.mock_response
       self.mock_response = None
       if data is None: return None
-    elif self.need_interface:
-        try:
-            data = self.dev.read(endpoint, size, timeout=timeout, interface=0)
-        except AttributeError:
-            data = self.dev.bulkRead(endpoint, size, timeout=timeout, interface=0)
     else:
-        try:
-            data = self.dev.read(endpoint, size, timeout=timeout)
-        except AttributeError:
-            data = self.dev.bulkRead(endpoint, size, timeout=timeout)
+      data = self.transport.read_bytes(size, timeout)
     if data is None:
       raise ValueError('read failed: none')
     if isinstance(data, (bytes, bytearray)):
@@ -730,8 +832,8 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     resp = b"None\x03"
     try:
       resp = self.read(timeout=5000)
-    except usb.core.USBError as e:
-      print("usb.core.USBError:", e, file=self.log)
+    except OSError as e:
+      print("read error in status():", e, file=self.log)
       pass
     if resp[-1] != CMD_ETX[0]:
       raise ValueError('status response not terminated with 0x03: %s' % (resp[-1]))

--- a/silhouette/Graphtec.py
+++ b/silhouette/Graphtec.py
@@ -614,11 +614,10 @@ Alternatively, you can add yourself to group 'lp' and logout/login.""" % (self.h
     return dev
 
   def _connect_bluetooth(self, bluetooth_addr, bluetooth_channel):
-    """Open a Bluetooth RFCOMM connection and identify the cutter model.
+    """Open an RFCOMM connection, setting self.transport and self.hardware.
 
-    Sets self.transport and self.hardware. The address must be explicit (use
-    the Bluetooth scan to discover it); the model is inferred from the firmware
-    version query (FG), or pass force_hardware to override it."""
+    The model is identified from the firmware query (FG) unless force_hardware
+    overrides it."""
     try:
       self.transport = BluetoothTransport.connect(bluetooth_addr, bluetooth_channel)
     except Exception as e:

--- a/silhouette/Transport.py
+++ b/silhouette/Transport.py
@@ -1,0 +1,325 @@
+# (c) 2026 inkscape-silhouette contributors
+#
+# Distribute under GPLv2 or ask.
+#
+# Transport abstraction for inkscape-silhouette.
+#
+# Separates the physical connection to a cutter (USB, Bluetooth, ...) from the
+# Graphtec command protocol implemented in Graphtec.py. The protocol layer
+# (SilhouetteCameo) only needs to push bytes down and read bytes back; the
+# details of *how* those bytes travel live in the Transport subclasses below.
+
+import re
+import socket
+import subprocess
+import sys
+
+
+class Transport:
+  """Abstract connection to a Silhouette cutter.
+
+  Concrete subclasses implement the low level byte transfer. Everything above
+  (the Graphtec command protocol) is transport agnostic and talks to a
+  Transport exclusively through write_bytes()/read_bytes().
+  """
+
+  # Human readable description of where the device sits, used for logging.
+  location = "unknown"
+
+  # Exception types raised by read_bytes()/write_bytes() on a timeout or a
+  # transient I/O error. The protocol layer catches these when polling.
+  timeout_exceptions = (OSError,)
+
+  def write_bytes(self, data, timeout):
+    """Write a chunk of bytes. Returns the number of bytes actually written.
+
+    timeout is given in milliseconds (to match the pyusb convention)."""
+    raise NotImplementedError
+
+  def read_bytes(self, size, timeout):
+    """Read up to size bytes and return them as bytes/bytearray.
+
+    timeout is given in milliseconds."""
+    raise NotImplementedError
+
+  def reset(self):
+    """Reset the connection, if the transport supports it. Default: no-op."""
+    pass
+
+  def close(self):
+    """Release the connection. Default: no-op."""
+    pass
+
+
+class USBTransport(Transport):
+  """USB connection via pyusb (Linux/Windows) or libusb1 (macOS).
+
+  The raw device object is discovered by Graphtec.SilhouetteCameo (which owns
+  the platform specific probing and the USB id tables) and handed to us here.
+  We only encapsulate the bulk read/write on the fixed endpoints.
+  """
+
+  ENDPOINT_WRITE = 0x01
+  ENDPOINT_READ = 0x82
+
+  def __init__(self, dev, need_interface=False):
+    self.dev = dev
+    # need_interface: some old versions of usb.core require an explicit
+    # interface= keyword; harmful on others. Kept for compatibility.
+    self.need_interface = need_interface
+
+    try:
+      bus = dev.bus
+    except Exception:
+      bus = -1
+    try:
+      address = dev.address
+    except Exception:
+      address = -1
+    self.bus = bus
+    self.address = address
+    self.location = "usb bus=%d addr=%d" % (bus, address)
+
+  def write_bytes(self, data, timeout):
+    endpoint = self.ENDPOINT_WRITE
+    if self.need_interface:
+      try:
+        return self.dev.write(endpoint, data, interface=0, timeout=timeout)
+      except AttributeError:
+        return self.dev.bulkWrite(endpoint, data, interface=0, timeout=timeout)
+    else:
+      try:
+        return self.dev.write(endpoint, data, timeout=timeout)
+      except AttributeError:
+        return self.dev.bulkWrite(endpoint, data, timeout=timeout)
+
+  def read_bytes(self, size, timeout):
+    endpoint = self.ENDPOINT_READ
+    if self.need_interface:
+      try:
+        return self.dev.read(endpoint, size, timeout=timeout, interface=0)
+      except AttributeError:
+        return self.dev.bulkRead(endpoint, size, timeout=timeout, interface=0)
+    else:
+      try:
+        return self.dev.read(endpoint, size, timeout=timeout)
+      except AttributeError:
+        return self.dev.bulkRead(endpoint, size, timeout=timeout)
+
+  def reset(self):
+    self.dev.reset()
+
+  def close(self):
+    # pyusb releases the device when it is garbage collected; historically
+    # this driver never explicitly closed it, so keep that behaviour.
+    pass
+
+
+class BluetoothTransport(Transport):
+  """Bluetooth connection over an RFCOMM serial port.
+
+  BT enabled cutters expose the very same Graphtec command protocol as over
+  USB, so once the socket is connected the protocol layer treats it exactly
+  like a USB device. The only differences are that there are no bulk endpoints
+  (we simply send/recv on the stream) and that timeouts are expressed in
+  seconds rather than milliseconds.
+  """
+
+  # RFCOMM channel used by the cutters. Channel 1 works for all known models.
+  DEFAULT_CHANNEL = 1
+
+  # socket.timeout is raised on read/write timeouts; it is a subclass of
+  # OSError but we list it explicitly for clarity.
+  timeout_exceptions = (socket.timeout, OSError)
+
+  def __init__(self, sock, address=None, channel=DEFAULT_CHANNEL):
+    self.sock = sock
+    self.address = address
+    self.channel = channel
+    self.bus = "bluetooth"
+    self.location = "bluetooth %s channel %d" % (address, channel)
+
+  @classmethod
+  def is_available(cls):
+    """True if this Python build/platform can open Bluetooth RFCOMM sockets."""
+    return (hasattr(socket, "AF_BLUETOOTH")
+            and hasattr(socket, "BTPROTO_RFCOMM"))
+
+  @classmethod
+  def connect(cls, address, channel=None, timeout=None):
+    """Open an RFCOMM connection to the cutter at the given MAC address.
+
+    address: bluetooth MAC address string, e.g. "00:1B:41:33:44:55".
+    channel: RFCOMM channel (defaults to DEFAULT_CHANNEL).
+    timeout: connection timeout in seconds (None: OS default).
+    """
+    if not cls.is_available():
+      raise RuntimeError(
+        "Bluetooth is not supported by this Python build/platform "
+        "(socket.AF_BLUETOOTH/BTPROTO_RFCOMM missing).")
+    if channel is None:
+      channel = cls.DEFAULT_CHANNEL
+    sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM,
+                         socket.BTPROTO_RFCOMM)
+    try:
+      if timeout is not None:
+        sock.settimeout(timeout)
+      sock.connect((address, channel))
+    except Exception:
+      sock.close()
+      raise
+    return cls(sock, address=address, channel=channel)
+
+  # ---- Discovery ---------------------------------------------------------
+  #
+  # Inkscape's static .inx UI cannot populate a dropdown at runtime, so we
+  # expose discovery as a helper that the --bluetooth_scan command uses to list
+  # cutters and their addresses for the user to choose from explicitly.
+  # Discovery is best effort and platform dependent; the cutter must already be
+  # paired with the operating system.
+
+  @staticmethod
+  def _format_addr(hex12):
+    """Turn a bare 12-hex-digit address into colon notation."""
+    h = hex12.upper()
+    return ":".join(h[i:i + 2] for i in range(0, 12, 2))
+
+  @classmethod
+  def discover(cls, timeout=8, name_filter=None):
+    """Discover reachable/paired Bluetooth devices.
+
+    Returns a list of (address, name) tuples, sorted by name. Best effort:
+    uses the OS list of paired devices (Windows PnP / BlueZ bluetoothctl) and
+    falls back to a live PyBluez inquiry if that library is installed. The
+    device must be paired with the OS first.
+
+    name_filter, if given, is a predicate on the device name; only devices for
+    which it returns true are returned (and only they short-circuit the slow
+    live-inquiry fallback). This keeps the transport model agnostic: callers
+    that want just Silhouette cutters pass a filter based on the model tables
+    in Graphtec, so there is no second list of model names to maintain here.
+    """
+    def matches(name):
+      return True if name_filter is None else bool(name_filter(name))
+
+    platform = sys.platform.lower()
+    backends = []
+    if platform.startswith("win"):
+      backends.append(cls._discover_windows)
+    elif platform.startswith("linux"):
+      backends.append(cls._discover_linux)
+    # Cross-platform live inquiry, only if PyBluez is available.
+    backends.append(cls._discover_pybluez)
+
+    seen = {}
+    for backend in backends:
+      try:
+        results = backend(timeout)
+      except Exception:
+        results = []
+      for addr, name in results:
+        key = (addr or "").upper()
+        if not key:
+          continue
+        # Keep the first sighting, but upgrade to a named entry if we get one.
+        if key not in seen or (not seen[key] and name):
+          seen[key] = name
+      # A fast paired-device backend already found a matching device: don't pay
+      # the multi-second cost of a live inquiry.
+      if backend is not cls._discover_pybluez and any(
+          matches(n) for n in seen.values()):
+        break
+
+    devices = list(seen.items())
+    if name_filter is not None:
+      devices = [(a, n) for (a, n) in devices if name_filter(n)]
+    return sorted(devices, key=lambda d: (d[1] or "", d[0]))
+
+  @staticmethod
+  def _run_quiet(args, timeout=30):
+    """Run a helper command, returning stdout (empty string on any failure)."""
+    kwargs = dict(capture_output=True, text=True, timeout=timeout)
+    if sys.platform.lower().startswith("win"):
+      # Avoid a console window flashing up inside the Inkscape UI.
+      kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    try:
+      return subprocess.run(args, **kwargs).stdout or ""
+    except Exception:
+      return ""
+
+  @classmethod
+  def _discover_windows(cls, timeout):
+    out = cls._run_quiet([
+      "powershell", "-NoProfile", "-Command",
+      "Get-PnpDevice -Class Bluetooth -ErrorAction SilentlyContinue | "
+      "ForEach-Object { $_.FriendlyName + '|' + $_.InstanceId }"])
+    return cls._parse_windows_pnp(out)
+
+  @classmethod
+  def _parse_windows_pnp(cls, text):
+    """Parse 'FriendlyName|InstanceId' lines from Get-PnpDevice.
+
+    Only classic (BTHENUM) device nodes carry an RFCOMM-connectable address;
+    the BTHLE (Bluetooth Low Energy) nodes advertise a different, non-RFCOMM
+    address and are ignored.
+    """
+    devices = []
+    pat = re.compile(r"BTHENUM\\DEV_([0-9A-Fa-f]{12})")
+    for line in text.splitlines():
+      if "|" not in line:
+        continue
+      name, instance_id = line.split("|", 1)
+      m = pat.search(instance_id)
+      if m:
+        devices.append((cls._format_addr(m.group(1)), name.strip()))
+    return devices
+
+  @classmethod
+  def _discover_linux(cls, timeout):
+    devices = []
+    for args in (["bluetoothctl", "devices"], ["bluetoothctl", "paired-devices"]):
+      devices.extend(cls._parse_bluetoothctl(cls._run_quiet(args)))
+    return devices
+
+  @classmethod
+  def _parse_bluetoothctl(cls, text):
+    """Parse 'Device AA:BB:CC:DD:EE:FF Name' lines from bluetoothctl."""
+    devices = []
+    pat = re.compile(r"^Device\s+([0-9A-Fa-f:]{17})\s+(.*)$")
+    for line in text.splitlines():
+      m = pat.match(line.strip())
+      if m:
+        devices.append((m.group(1).upper(), m.group(2).strip()))
+    return devices
+
+  @classmethod
+  def _discover_pybluez(cls, timeout):
+    try:
+      import bluetooth  # PyBluez; optional dependency
+    except Exception:
+      return []
+    found = bluetooth.discover_devices(duration=max(1, int(timeout)),
+                                       lookup_names=True)
+    return [(addr, name) for addr, name in found]
+
+  @staticmethod
+  def _timeout_seconds(timeout_ms):
+    if timeout_ms is None or timeout_ms <= 0:
+      return None
+    return timeout_ms / 1000.0
+
+  def write_bytes(self, data, timeout):
+    self.sock.settimeout(self._timeout_seconds(timeout))
+    # RFCOMM is a reliable stream: sendall pushes the whole chunk or raises.
+    self.sock.sendall(data)
+    return len(data)
+
+  def read_bytes(self, size, timeout):
+    self.sock.settimeout(self._timeout_seconds(timeout))
+    return self.sock.recv(size)
+
+  def close(self):
+    try:
+      self.sock.close()
+    except Exception:
+      pass

--- a/silhouette/Transport.py
+++ b/silhouette/Transport.py
@@ -16,11 +16,10 @@ import sys
 
 
 class Transport:
-  """Abstract connection to a Silhouette cutter.
+  """Abstract connection to a cutter.
 
-  Concrete subclasses implement the low level byte transfer. Everything above
-  (the Graphtec command protocol) is transport agnostic and talks to a
-  Transport exclusively through write_bytes()/read_bytes().
+  The protocol layer (Graphtec.SilhouetteCameo) talks to a transport only
+  through write_bytes()/read_bytes(); subclasses supply the byte transfer.
   """
 
   # Human readable description of where the device sits, used for logging.
@@ -54,9 +53,8 @@ class Transport:
 class USBTransport(Transport):
   """USB connection via pyusb (Linux/Windows) or libusb1 (macOS).
 
-  The raw device object is discovered by Graphtec.SilhouetteCameo (which owns
-  the platform specific probing and the USB id tables) and handed to us here.
-  We only encapsulate the bulk read/write on the fixed endpoints.
+  The raw device is discovered and handed in by Graphtec.SilhouetteCameo; this
+  only wraps the bulk read/write on the fixed endpoints.
   """
 
   ENDPOINT_WRITE = 0x01
@@ -118,11 +116,8 @@ class USBTransport(Transport):
 class BluetoothTransport(Transport):
   """Bluetooth connection over an RFCOMM serial port.
 
-  BT enabled cutters expose the very same Graphtec command protocol as over
-  USB, so once the socket is connected the protocol layer treats it exactly
-  like a USB device. The only differences are that there are no bulk endpoints
-  (we simply send/recv on the stream) and that timeouts are expressed in
-  seconds rather than milliseconds.
+  BT cutters speak the same Graphtec protocol as over USB; unlike USB there are
+  no bulk endpoints (plain stream send/recv) and timeouts are in seconds.
   """
 
   # RFCOMM channel used by the cutters. Channel 1 works for all known models.
@@ -172,11 +167,9 @@ class BluetoothTransport(Transport):
 
   # ---- Discovery ---------------------------------------------------------
   #
-  # Inkscape's static .inx UI cannot populate a dropdown at runtime, so we
-  # expose discovery as a helper that the --bluetooth_scan command uses to list
-  # cutters and their addresses for the user to choose from explicitly.
-  # Discovery is best effort and platform dependent; the cutter must already be
-  # paired with the operating system.
+  # Used by the --bluetooth_scan command to list paired cutters for the user to
+  # pick from (Inkscape's static .inx cannot populate a dropdown at runtime).
+  # Best effort and platform dependent; the cutter must already be OS-paired.
 
   @staticmethod
   def _format_addr(hex12):
@@ -185,38 +178,45 @@ class BluetoothTransport(Transport):
     return ":".join(h[i:i + 2] for i in range(0, 12, 2))
 
   @classmethod
+  def _paired_backends(cls):
+    """Fast 'already paired' discovery backends for the current platform."""
+    platform = sys.platform.lower()
+    if platform.startswith("win"):
+      return [cls._discover_windows]
+    if platform.startswith("linux"):
+      return [cls._discover_linux]
+    return []
+
+  @classmethod
   def discover(cls, timeout=8, name_filter=None):
-    """Discover reachable/paired Bluetooth devices.
+    """Discover paired/reachable Bluetooth devices as sorted (address, name) tuples.
 
-    Returns a list of (address, name) tuples, sorted by name. Best effort:
-    uses the OS list of paired devices (Windows PnP / BlueZ bluetoothctl) and
-    falls back to a live PyBluez inquiry if that library is installed. The
-    device must be paired with the OS first.
+    Best effort; the device must already be OS-paired. name_filter, if given,
+    restricts the result by name -- callers pass Graphtec's model matcher to
+    list only Silhouette cutters, so no device-name list is duplicated here.
+    """
+    # Fast path: the OS's list of already-paired devices for this platform.
+    # Fallback: a live PyBluez inquiry, tried only when the fast path finds no
+    # match, and itself a no-op when PyBluez is not installed.
+    return cls._collect_devices(
+        paired_backends=cls._paired_backends(),
+        inquiry_backend=cls._discover_pybluez,
+        timeout=timeout,
+        name_filter=name_filter)
 
-    name_filter, if given, is a predicate on the device name; only devices for
-    which it returns true are returned (and only they short-circuit the slow
-    live-inquiry fallback). This keeps the transport model agnostic: callers
-    that want just Silhouette cutters pass a filter based on the model tables
-    in Graphtec, so there is no second list of model names to maintain here.
+  @staticmethod
+  def _collect_devices(paired_backends, inquiry_backend, timeout, name_filter):
+    """Merge injected discovery backends into a sorted (address, name) list.
+
+    The paired backends run first; the slow inquiry_backend (PyBluez) is a
+    fallback used only when they yield no name_filter match.
     """
     def matches(name):
       return True if name_filter is None else bool(name_filter(name))
 
-    platform = sys.platform.lower()
-    backends = []
-    if platform.startswith("win"):
-      backends.append(cls._discover_windows)
-    elif platform.startswith("linux"):
-      backends.append(cls._discover_linux)
-    # Cross-platform live inquiry, only if PyBluez is available.
-    backends.append(cls._discover_pybluez)
-
     seen = {}
-    for backend in backends:
-      try:
-        results = backend(timeout)
-      except Exception:
-        results = []
+
+    def collect(results):
       for addr, name in results:
         key = (addr or "").upper()
         if not key:
@@ -224,11 +224,24 @@ class BluetoothTransport(Transport):
         # Keep the first sighting, but upgrade to a named entry if we get one.
         if key not in seen or (not seen[key] and name):
           seen[key] = name
+
+    found_match = False
+    for backend in paired_backends:
+      try:
+        collect(backend(timeout))
+      except Exception:
+        pass
       # A fast paired-device backend already found a matching device: don't pay
       # the multi-second cost of a live inquiry.
-      if backend is not cls._discover_pybluez and any(
-          matches(n) for n in seen.values()):
+      if any(matches(n) for n in seen.values()):
+        found_match = True
         break
+
+    if not found_match and inquiry_backend is not None:
+      try:
+        collect(inquiry_backend(timeout))
+      except Exception:
+        pass
 
     devices = list(seen.items())
     if name_filter is not None:

--- a/test/test_bluetooth.py
+++ b/test/test_bluetooth.py
@@ -237,72 +237,93 @@ class DiscoveryParsingTest(unittest.TestCase):
         self.assertIn(("11:22:33:44:55:66", "Generic BT Speaker"), devices)
 
 
-class DiscoverTest(unittest.TestCase):
-    """discover() aggregates backends, applies the name filter, and dedups."""
+class CollectDevicesTest(unittest.TestCase):
+    """The platform-independent aggregation core of discover().
+
+    Backends are injected directly, so these test the real merge / filter /
+    short-circuit logic without any reference to the host platform.
+    """
 
     CUTTER = ("00:1B:41:33:44:55", "CAMEO 5 ALPHA-000000")
     OTHER = ("11:22:33:44:55:66", "Generic BT Speaker")
 
-    def _patch_backends(self, win=None, linux=None, pybluez=None):
-        return [
-            mock.patch.object(BluetoothTransport, "_discover_windows",
-                              classmethod(lambda cls, t: list(win or []))),
-            mock.patch.object(BluetoothTransport, "_discover_linux",
-                              classmethod(lambda cls, t: list(linux or []))),
-            mock.patch.object(BluetoothTransport, "_discover_pybluez",
-                              classmethod(lambda cls, t: list(pybluez or []))),
-        ]
+    @staticmethod
+    def backend(devices):
+        """A fake discovery backend that returns a fixed device list."""
+        return lambda timeout: list(devices)
+
+    def collect(self, paired, inquiry, name_filter=None):
+        return BluetoothTransport._collect_devices(paired, inquiry, 8, name_filter)
 
     def test_name_filter_selects_matching_devices(self):
-        patches = self._patch_backends(win=[self.CUTTER, self.OTHER])
-        for p in patches: p.start()
-        try:
-            # The scan filters to Silhouette cutters via Graphtec's model table.
-            self.assertEqual(
-                BluetoothTransport.discover(name_filter=is_silhouette_name),
-                [self.CUTTER])
-            # With no filter, every device is returned.
-            self.assertEqual(len(BluetoothTransport.discover()), 2)
-        finally:
-            for p in patches: p.stop()
+        paired = [self.backend([self.CUTTER, self.OTHER])]
+        # Filtered to Silhouette cutters via Graphtec's model table.
+        self.assertEqual(
+            self.collect(paired, None, name_filter=is_silhouette_name),
+            [self.CUTTER])
+        # With no filter, every device is returned.
+        self.assertEqual(len(self.collect(paired, None)), 2)
 
-    def test_fast_backend_short_circuits_pybluez(self):
-        # If the OS paired list already yields a matching cutter, no live
-        # inquiry runs.
-        pybluez_called = []
+    def test_fast_backend_short_circuits_inquiry(self):
+        # A paired backend already found a matching cutter: the slow live
+        # inquiry backend must never be invoked.
+        inquiry_called = []
 
-        def spy(cls, t):
-            pybluez_called.append(True)
+        def inquiry(timeout):
+            inquiry_called.append(True)
             return []
-        patches = [
-            mock.patch.object(BluetoothTransport, "_discover_windows",
-                              classmethod(lambda cls, t: [self.CUTTER])),
-            mock.patch.object(BluetoothTransport, "_discover_linux",
-                              classmethod(lambda cls, t: [])),
-            mock.patch.object(BluetoothTransport, "_discover_pybluez",
-                              classmethod(spy)),
-        ]
-        for p in patches: p.start()
-        try:
-            BluetoothTransport.discover(name_filter=is_silhouette_name)
-            self.assertEqual(pybluez_called, [])
-        finally:
-            for p in patches: p.stop()
+        self.collect([self.backend([self.CUTTER])], inquiry,
+                     name_filter=is_silhouette_name)
+        self.assertEqual(inquiry_called, [])
+
+    def test_inquiry_runs_when_no_paired_match(self):
+        # Paired backend found only a non-matching device, so we fall back to
+        # the live inquiry, which turns up the cutter.
+        inquiry_called = []
+
+        def inquiry(timeout):
+            inquiry_called.append(True)
+            return [self.CUTTER]
+        result = self.collect([self.backend([self.OTHER])], inquiry,
+                              name_filter=is_silhouette_name)
+        self.assertEqual(inquiry_called, [True])
+        self.assertEqual(result, [self.CUTTER])
 
     def test_backend_exception_is_swallowed(self):
-        def boom(cls, t):
+        def boom(timeout):
             raise RuntimeError("tool missing")
-        patches = [
-            mock.patch.object(BluetoothTransport, "_discover_windows", classmethod(boom)),
-            mock.patch.object(BluetoothTransport, "_discover_linux", classmethod(boom)),
-            mock.patch.object(BluetoothTransport, "_discover_pybluez",
-                              classmethod(lambda cls, t: [self.CUTTER])),
-        ]
-        for p in patches: p.start()
-        try:
-            self.assertEqual(BluetoothTransport.discover(), [self.CUTTER])
-        finally:
-            for p in patches: p.stop()
+        result = self.collect([boom], self.backend([self.CUTTER]))
+        self.assertEqual(result, [self.CUTTER])
+
+    def test_dedups_by_address_preferring_named(self):
+        # The same address arrives twice (different case, one unnamed); the
+        # named sighting wins and only one entry remains.
+        paired = [self.backend([
+            ("00:1B:41:33:44:55", ""),
+            ("00:1b:41:33:44:55", "CAMEO 5 ALPHA-000000"),
+        ])]
+        self.assertEqual(self.collect(paired, None),
+                         [("00:1B:41:33:44:55", "CAMEO 5 ALPHA-000000")])
+
+
+class PairedBackendSelectionTest(unittest.TestCase):
+    """_paired_backends() picks the right fast backend for each platform."""
+
+    def _backends_on(self, platform):
+        with mock.patch("silhouette.Transport.sys.platform", platform):
+            return BluetoothTransport._paired_backends()
+
+    def test_windows_uses_pnp(self):
+        self.assertEqual(self._backends_on("win32"),
+                         [BluetoothTransport._discover_windows])
+
+    def test_linux_uses_bluetoothctl(self):
+        self.assertEqual(self._backends_on("linux"),
+                         [BluetoothTransport._discover_linux])
+
+    def test_macos_has_no_paired_backend(self):
+        # macOS lacks RFCOMM sockets; only the (optional) live inquiry applies.
+        self.assertEqual(self._backends_on("darwin"), [])
 
 
 if __name__ == "__main__":

--- a/test/test_bluetooth.py
+++ b/test/test_bluetooth.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+
+# Tests for the Bluetooth (RFCOMM) transport and the model detection that lets
+# a SilhouetteCameo talk to a cutter over Bluetooth instead of USB.
+#
+# These tests do not need real hardware (nor a Bluetooth stack): they drive the
+# driver through a fake socket that speaks just enough of the Graphtec protocol
+# (firmware query "FG" and the ESC-ENQ status request).
+
+import io
+import socket
+import unittest
+from unittest import mock
+
+from silhouette.Transport import BluetoothTransport, Transport
+from silhouette.Graphtec import (
+    SilhouetteCameo,
+    _match_bluetooth_hardware,
+    PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA,
+    PRODUCT_ID_SILHOUETTE_CAMEO3,
+)
+
+
+class FakeRfcommSocket:
+    """Minimal stand-in for an RFCOMM socket speaking the Graphtec protocol."""
+
+    def __init__(self, firmware=b"CAMEO 5 ALPHA V1.02    ", status=b"0"):
+        self.firmware = firmware
+        self.status = status
+        self.buf = b""
+        self.sent = []
+        self.timeout = None
+        self.closed = False
+
+    def settimeout(self, t):
+        self.timeout = t
+
+    def sendall(self, data):
+        self.sent.append(bytes(data))
+        if data == b"FG\x03":                 # firmware version query
+            self.buf = self.firmware + b"\x03"
+        elif data == b"\x1b\x05":             # ESC ENQ -> status request
+            self.buf = self.status + b"\x03"
+        else:
+            self.buf = b""
+
+    def recv(self, size):
+        if not self.buf:
+            # Mirror a real socket read timeout with no data pending.
+            raise socket.timeout("no data")
+        data, self.buf = self.buf[:size], self.buf[size:]
+        return data
+
+    def close(self):
+        self.closed = True
+
+
+def make_bt_cameo(firmware=b"CAMEO 5 ALPHA V1.02    ", status=b"0",
+                  force_hardware=None):
+    """Build a SilhouetteCameo wired to a FakeRfcommSocket."""
+    fake = FakeRfcommSocket(firmware=firmware, status=status)
+    transport = BluetoothTransport(fake, address="00:11:22:33:44:55")
+    with mock.patch.object(BluetoothTransport, "connect",
+                           classmethod(lambda cls, addr, ch=None, timeout=None: transport)):
+        dev = SilhouetteCameo(log=io.StringIO(),
+                              bluetooth_addr="00:11:22:33:44:55",
+                              force_hardware=force_hardware)
+    return dev, fake
+
+
+def is_silhouette_name(name):
+    """The predicate the Bluetooth scan uses: matches known Silhouette models.
+
+    Deliberately reuses Graphtec's model table (via _match_bluetooth_hardware)
+    so there is no second list of device names to keep in sync."""
+    return _match_bluetooth_hardware(name) is not None
+
+
+class MatchBluetoothHardwareTest(unittest.TestCase):
+    """The advertised BLE name / FG response resolves to a DEVICE entry."""
+
+    def test_cameo5_alpha_with_firmware_suffix(self):
+        hw = _match_bluetooth_hardware("CAMEO 5 ALPHA V1.02")
+        self.assertIsNotNone(hw)
+        self.assertEqual(hw["product_id"], PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA)
+
+    def test_specificity_ordering(self):
+        # "CAMEO 5 ALPHA PLUS" must not be shadowed by "CAMEO 5 ALPHA".
+        hw = _match_bluetooth_hardware("CAMEO 5 ALPHA PLUS V1.0")
+        self.assertEqual(hw["name"], "Silhouette_Cameo5_Alpha_Plus")
+
+    def test_plain_cameo5(self):
+        self.assertEqual(
+            _match_bluetooth_hardware("CAMEO 5 V2.1")["name"],
+            "Silhouette_Cameo5")
+
+    def test_cameo3_no_space(self):
+        self.assertEqual(
+            _match_bluetooth_hardware("CAMEO3 V1")["product_id"],
+            PRODUCT_ID_SILHOUETTE_CAMEO3)
+
+    def test_case_insensitive(self):
+        self.assertEqual(
+            _match_bluetooth_hardware("cameo 5 alpha v1.02")["product_id"],
+            PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA)
+
+    def test_unknown_returns_none(self):
+        self.assertIsNone(_match_bluetooth_hardware("SOME RANDOM DEVICE"))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(_match_bluetooth_hardware(""))
+        self.assertIsNone(_match_bluetooth_hardware(None))
+
+
+class BluetoothTransportTest(unittest.TestCase):
+    """The RFCOMM transport's low level byte transfer."""
+
+    def test_is_a_transport(self):
+        self.assertTrue(issubclass(BluetoothTransport, Transport))
+
+    def test_write_bytes_uses_sendall(self):
+        fake = FakeRfcommSocket()
+        t = BluetoothTransport(fake, address="AA:BB")
+        n = t.write_bytes(b"HELLO", timeout=5000)
+        self.assertEqual(n, len(b"HELLO"))
+        self.assertEqual(fake.sent[-1], b"HELLO")
+        # timeout is converted from ms to seconds
+        self.assertAlmostEqual(fake.timeout, 5.0)
+
+    def test_read_bytes_returns_recv(self):
+        fake = FakeRfcommSocket()
+        t = BluetoothTransport(fake, address="AA:BB")
+        fake.sendall(b"FG\x03")
+        data = t.read_bytes(64, timeout=1000)
+        self.assertEqual(data, b"CAMEO 5 ALPHA V1.02    \x03")
+        self.assertAlmostEqual(fake.timeout, 1.0)
+
+    def test_zero_timeout_is_blocking(self):
+        fake = FakeRfcommSocket()
+        t = BluetoothTransport(fake, address="AA:BB")
+        t.write_bytes(b"x", timeout=0)
+        self.assertIsNone(fake.timeout)
+
+    def test_close(self):
+        fake = FakeRfcommSocket()
+        t = BluetoothTransport(fake, address="AA:BB")
+        t.close()
+        self.assertTrue(fake.closed)
+
+    def test_location_string(self):
+        fake = FakeRfcommSocket()
+        t = BluetoothTransport(fake, address="00:1B:41:33:44:55", channel=1)
+        self.assertIn("00:1B:41:33:44:55", t.location)
+
+    def test_connect_requires_bluetooth_support(self):
+        with mock.patch.object(BluetoothTransport, "is_available",
+                               classmethod(lambda cls: False)):
+            with self.assertRaises(RuntimeError):
+                BluetoothTransport.connect("00:11:22:33:44:55")
+
+
+class CameoOverBluetoothTest(unittest.TestCase):
+    """End to end: a SilhouetteCameo driven over the fake RFCOMM socket."""
+
+    def test_model_detected_from_firmware(self):
+        dev, fake = make_bt_cameo()
+        self.assertEqual(dev.hardware["name"], "Silhouette_Cameo5_Alpha")
+        self.assertEqual(dev.product_id(), PRODUCT_ID_SILHOUETTE_CAMEO5ALPHA)
+        self.assertIsInstance(dev.transport, BluetoothTransport)
+
+    def test_status_and_version_over_bt(self):
+        dev, fake = make_bt_cameo()
+        self.assertEqual(dev.status(), "ready")
+        # get_version returns the raw firmware string (padding preserved).
+        self.assertEqual(dev.get_version().strip(), "CAMEO 5 ALPHA V1.02")
+        # The firmware query really went out over the socket.
+        self.assertIn(b"FG\x03", fake.sent)
+
+    def test_force_hardware_overrides_detection(self):
+        dev, fake = make_bt_cameo(force_hardware="Silhouette_Cameo3")
+        self.assertEqual(dev.hardware["name"], "Silhouette_Cameo3")
+
+    def test_unknown_model_is_flagged(self):
+        dev, fake = make_bt_cameo(firmware=b"MYSTERY CUTTER V9")
+        self.assertIn("Unknown Bluetooth", dev.hardware["name"])
+        # We still have a working transport; only the model is unresolved.
+        self.assertIsInstance(dev.transport, BluetoothTransport)
+
+    def test_dry_run_falls_back_to_dummy_on_connect_failure(self):
+        def boom(cls, addr, ch=None, timeout=None):
+            raise OSError("no such device")
+        with mock.patch.object(BluetoothTransport, "connect",
+                               classmethod(boom)):
+            dev = SilhouetteCameo(log=io.StringIO(),
+                                  dry_run=True,
+                                  bluetooth_addr="00:11:22:33:44:55")
+        self.assertIsNone(dev.transport)
+        self.assertEqual(dev.hardware["name"], "Crashtest Dummy Device")
+
+    def test_connect_failure_without_dry_run_raises(self):
+        def boom(cls, addr, ch=None, timeout=None):
+            raise OSError("no such device")
+        with mock.patch.object(BluetoothTransport, "connect",
+                               classmethod(boom)):
+            with self.assertRaises(ValueError):
+                SilhouetteCameo(log=io.StringIO(),
+                                bluetooth_addr="00:11:22:33:44:55")
+
+
+class DiscoveryParsingTest(unittest.TestCase):
+    """Parsing of the platform tools' output and name/address helpers."""
+
+    def test_format_addr(self):
+        self.assertEqual(BluetoothTransport._format_addr("001B41334455"),
+                         "00:1B:41:33:44:55")
+
+    def test_parse_windows_pnp_keeps_classic_ignores_ble(self):
+        # A cutter shows up twice: as a BLE (BTHLE) node and a classic (BTHENUM)
+        # node. Only the classic node is RFCOMM-connectable, so only it is kept.
+        text = "\r\n".join([
+            "CAMEO 5 ALPHA-000000|BTHLE\\DEV_C01B41334455\\B&1111111&0&C01B41334455",
+            "CAMEO 5 ALPHA-000000|BTHENUM\\DEV_001B41334455\\B&2222222&0&BLUETOOTHDEVICE_001B41334455",
+            "Some Mouse|USB\\VID_1234&PID_5678\\6&abcd",
+            "",
+        ])
+        devices = BluetoothTransport._parse_windows_pnp(text)
+        self.assertEqual(devices, [("00:1B:41:33:44:55", "CAMEO 5 ALPHA-000000")])
+
+    def test_parse_bluetoothctl(self):
+        text = "\n".join([
+            "Device 00:1B:41:33:44:55 CAMEO 5 ALPHA-000000",
+            "Device 11:22:33:44:55:66 Generic BT Speaker",
+            "garbage line",
+        ])
+        devices = BluetoothTransport._parse_bluetoothctl(text)
+        self.assertIn(("00:1B:41:33:44:55", "CAMEO 5 ALPHA-000000"), devices)
+        self.assertIn(("11:22:33:44:55:66", "Generic BT Speaker"), devices)
+
+
+class DiscoverTest(unittest.TestCase):
+    """discover() aggregates backends, applies the name filter, and dedups."""
+
+    CUTTER = ("00:1B:41:33:44:55", "CAMEO 5 ALPHA-000000")
+    OTHER = ("11:22:33:44:55:66", "Generic BT Speaker")
+
+    def _patch_backends(self, win=None, linux=None, pybluez=None):
+        return [
+            mock.patch.object(BluetoothTransport, "_discover_windows",
+                              classmethod(lambda cls, t: list(win or []))),
+            mock.patch.object(BluetoothTransport, "_discover_linux",
+                              classmethod(lambda cls, t: list(linux or []))),
+            mock.patch.object(BluetoothTransport, "_discover_pybluez",
+                              classmethod(lambda cls, t: list(pybluez or []))),
+        ]
+
+    def test_name_filter_selects_matching_devices(self):
+        patches = self._patch_backends(win=[self.CUTTER, self.OTHER])
+        for p in patches: p.start()
+        try:
+            # The scan filters to Silhouette cutters via Graphtec's model table.
+            self.assertEqual(
+                BluetoothTransport.discover(name_filter=is_silhouette_name),
+                [self.CUTTER])
+            # With no filter, every device is returned.
+            self.assertEqual(len(BluetoothTransport.discover()), 2)
+        finally:
+            for p in patches: p.stop()
+
+    def test_fast_backend_short_circuits_pybluez(self):
+        # If the OS paired list already yields a matching cutter, no live
+        # inquiry runs.
+        pybluez_called = []
+
+        def spy(cls, t):
+            pybluez_called.append(True)
+            return []
+        patches = [
+            mock.patch.object(BluetoothTransport, "_discover_windows",
+                              classmethod(lambda cls, t: [self.CUTTER])),
+            mock.patch.object(BluetoothTransport, "_discover_linux",
+                              classmethod(lambda cls, t: [])),
+            mock.patch.object(BluetoothTransport, "_discover_pybluez",
+                              classmethod(spy)),
+        ]
+        for p in patches: p.start()
+        try:
+            BluetoothTransport.discover(name_filter=is_silhouette_name)
+            self.assertEqual(pybluez_called, [])
+        finally:
+            for p in patches: p.stop()
+
+    def test_backend_exception_is_swallowed(self):
+        def boom(cls, t):
+            raise RuntimeError("tool missing")
+        patches = [
+            mock.patch.object(BluetoothTransport, "_discover_windows", classmethod(boom)),
+            mock.patch.object(BluetoothTransport, "_discover_linux", classmethod(boom)),
+            mock.patch.object(BluetoothTransport, "_discover_pybluez",
+                              classmethod(lambda cls, t: [self.CUTTER])),
+        ]
+        for p in patches: p.start()
+        try:
+            self.assertEqual(BluetoothTransport.discover(), [self.CUTTER])
+        finally:
+            for p in patches: p.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What Changed
- Add built-in Bluetooth support.
- Bluetooth is added via Bluetooth classic - BLE exists for the cutters, but 1. doesn't come out of the box for Python under `socket` and 2. isn't nearly as stable of a connection for sending large jobs.
- Add new Bluetooth tab to the extension for configuring Bluetooth.
  - If `bluetooth_addr` is specified, cutter sends over Bluetooth.
  - Add small "scan" path/option (`bluetooth_scan`) for making it easier to determine your cutter's BT MAC.
- Refactor USB communication into a new `Transport` class alongside Bluetooth comms.
- Add device detection for Bluetooth
  - Based on observed behavior in Silhouette Studio, Studio determines connected cutter type when connected to BT by name, so we do the same here
 - Add new translation strings to `.po` files.

## How It Was Tested
- Tested with my Cameo Alpha 5a, correctly identified via version commands, cutting works as expected.
- Added new test suite for bluetooth
- All existing tests pass

## Known Limitations
- Windows and Linux both allow `socket.AF_BLUETOOTH`, but MacOS _does not_.  It might be possible to get this working via another path on Mac, since I _think_ MacOS opens a socket device when you pair/connect with a cutter, but I have no way of testing this.

Closes #88 