### PR TITLE
feat: add Cameo 5 Alpha A4 regmark template

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -23,6 +23,7 @@ Therefore it is necessary to set the correct offset values of the mark.
 As a result the cut will go precisely along the graphics.
 
 1. Extention > Render > Silhouette Regmarks
+1. For a Cameo 5 Alpha, select **4 corner (four L-marks, e.g. Cameo 5 Alpha)** as the registration mark style
 1. Check regmark from document left and top is set to desired value
 1. Set mark to mark distance or clear it to zero if autocalculating from document size
 1. Press Apply
@@ -32,7 +33,7 @@ This will create a new layer called `Regmarks` with the newly generated registra
 On the bottom will also be a string shown below that would remind you what settings this was generated with.
 - `mark distance from document: Left=10.0mm, Top=10.0mm; mark to mark distance: X=190.0mm, Y=277.0mm;`
 
-Note: You have the option of using the provided template at `examples/registration-marks-cameo-silhouette-a4-maxi.svg` for Silhouette Cameo using A4 paper format.
+Note: You have the option of using the provided template at `examples/registration-marks-cameo-silhouette-a4-maxi.svg` for Silhouette Cameo using A4 paper format. Cameo 5 Alpha users can use the ready-made A4 template at `templates/silhouette-cameo-5-alpha-registration-marks-a4.svg` without running the regmark generator.
 
 
 ---
@@ -69,6 +70,7 @@ Note: You have the option of using the provided template at `examples/registrati
 5. On the **Regmarks** tab:
   - Check **Document has registration marks**
   - Check **Search for registration marks**
+  - On a Cameo 5 Alpha, also check **Use 4 registration marks**
 6. Set all following parameters according to the registration file used:
   - **X mark distance** (e.g. *190*)
   - **Y mark distance** (e.g. *277*)

--- a/templates/silhouette-cameo-5-alpha-registration-marks-a4.svg
+++ b/templates/silhouette-cameo-5-alpha-registration-marks-a4.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   id="cameo-5-alpha-a4"
+   version="1.1">
+  <inkscape:_templateinfo>
+    <inkscape:_name>Silhouette Cameo 5 Alpha - A4</inkscape:_name>
+    <inkscape:author>inkscape-silhouette contributors</inkscape:author>
+    <inkscape:_shortdesc>A4 template with four-point Cameo 5 Alpha registration marks</inkscape:_shortdesc>
+    <inkscape:_keywords>Silhouette Cameo 5 Alpha A4 registration marks</inkscape:_keywords>
+  </inkscape:_templateinfo>
+  <g
+     id="regmark"
+     inkscape:groupmode="layer"
+     inkscape:label="Regmarks"
+     sodipodi:insensitive="true"
+     fill="none"
+     stroke="#000000"
+     stroke-width="0.3"
+     stroke-linecap="square"
+     stroke-linejoin="miter">
+    <path id="regmark-tl" d="M 30,10 H 10 V 30" />
+    <path id="regmark-tr" d="M 180,10 H 200 V 30" />
+    <path id="regmark-bl" d="M 30,287 H 10 V 267" />
+    <path id="regmark-br" d="M 180,287 H 200 V 267" />
+  </g>
+  <g
+     id="print"
+     inkscape:groupmode="layer"
+     inkscape:label="Print" />
+  <g
+     id="cut"
+     inkscape:groupmode="layer"
+     inkscape:label="Cut" />
+</svg>

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -1,0 +1,52 @@
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree
+
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+INKSCAPE_NAMESPACE = "http://www.inkscape.org/namespaces/inkscape"
+TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "templates"
+    / "silhouette-cameo-5-alpha-registration-marks-a4.svg"
+)
+
+
+class Cameo5AlphaA4TemplateTest(unittest.TestCase):
+    def setUp(self):
+        self.root = ElementTree.parse(TEMPLATE_PATH).getroot()
+        self.elements_by_id = {
+            element.get("id"): element for element in self.root.iter()
+        }
+
+    def test_page_size(self):
+        self.assertEqual(self.root.get("width"), "210mm")
+        self.assertEqual(self.root.get("height"), "297mm")
+        self.assertEqual(self.root.get("viewBox"), "0 0 210 297")
+
+    def test_four_corner_mark_geometry(self):
+        expected_paths = {
+            "regmark-tl": "M 30,10 H 10 V 30",
+            "regmark-tr": "M 180,10 H 200 V 30",
+            "regmark-bl": "M 30,287 H 10 V 267",
+            "regmark-br": "M 180,287 H 200 V 267",
+        }
+
+        for mark_id, path in expected_paths.items():
+            mark = self.elements_by_id[mark_id]
+            self.assertEqual(mark.tag, f"{{{SVG_NAMESPACE}}}path")
+            self.assertEqual(mark.get("d"), path)
+
+    def test_regmark_layer_style(self):
+        layer = self.elements_by_id["regmark"]
+
+        self.assertEqual(
+            layer.get(f"{{{INKSCAPE_NAMESPACE}}}label"),
+            "Regmarks",
+        )
+        self.assertEqual(layer.get("stroke"), "#000000")
+        self.assertEqual(layer.get("stroke-width"), "0.3")
+        self.assertEqual(layer.get("stroke-linecap"), "square")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -12,18 +12,9 @@ TEMPLATE_PATH = (
 
 
 class Cameo5AlphaA4TemplateTest(unittest.TestCase):
-    def setUp(self):
-        self.root = ElementTree.parse(TEMPLATE_PATH).getroot()
-        self.elements_by_id = {
-            element.get("id"): element for element in self.root.iter()
-        }
-
-    def test_page_size(self):
-        self.assertEqual(self.root.get("width"), "210mm")
-        self.assertEqual(self.root.get("height"), "297mm")
-        self.assertEqual(self.root.get("viewBox"), "0 0 210 297")
-
-    def test_four_corner_mark_geometry(self):
+    def test_page_and_regmark_geometry(self):
+        root = ElementTree.parse(TEMPLATE_PATH).getroot()
+        elements_by_id = {element.get("id"): element for element in root.iter()}
         expected_paths = {
             "regmark-tl": "M 30,10 H 10 V 30",
             "regmark-tr": "M 180,10 H 200 V 30",
@@ -31,14 +22,16 @@ class Cameo5AlphaA4TemplateTest(unittest.TestCase):
             "regmark-br": "M 180,287 H 200 V 267",
         }
 
+        self.assertEqual(
+            (root.get("width"), root.get("height"), root.get("viewBox")),
+            ("210mm", "297mm", "0 0 210 297"),
+        )
         for mark_id, path in expected_paths.items():
-            mark = self.elements_by_id[mark_id]
+            mark = elements_by_id[mark_id]
             self.assertEqual(mark.tag, f"{{{SVG_NAMESPACE}}}path")
             self.assertEqual(mark.get("d"), path)
 
-    def test_regmark_layer_style(self):
-        layer = self.elements_by_id["regmark"]
-
+        layer = elements_by_id["regmark"]
         self.assertEqual(
             layer.get(f"{{{INKSCAPE_NAMESPACE}}}label"),
             "Regmarks",


### PR DESCRIPTION
## Why This Change

Four-corner registration mark generation is available after #374, but Cameo 5 Alpha users still need to run the Inkscape extension before preparing an A4 print-and-cut document. A ready-made SVG template makes the common A4 setup available directly and can be used without running the generator.

## What Changed

- Add an A4 Cameo 5 Alpha SVG template with four inward-facing L marks.
- Place mark corners 10 mm from each page edge, giving 190 × 277 mm mark spacing.
- Use the existing generator's 20 mm arm length, 0.3 mm stroke width, and `regmark-tl`, `regmark-tr`, `regmark-bl`, and `regmark-br` IDs.
- Include ready-to-use `Print` and `Cut` layers.
- Document four-corner generation, the standalone template, and the required four-mark scan option.
- Add focused tests for page dimensions, mark geometry, IDs, and layer styling.

## How It Was Tested

- `ruff format test/test_templates.py`
- `ruff check test/test_templates.py`
- `python3 -m unittest -v test.test_templates`
- `python3 -m py_compile test/test_templates.py`
- `xmllint --noout templates/silhouette-cameo-5-alpha-registration-marks-a4.svg render_silhouette_regmarks.inx`
- `git diff --check`
- Rendered the template to PNG with Inkscape and visually verified all four marks.

