### PR TITLE
Do not start job if warnings exist

### DIFF
--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -709,6 +709,15 @@ class SendtoSilhouette(EffectExtension):
             # Traverse the entire document
             self.recursivelyTraverseSvg(self.document.getroot())
 
+        if self.warnings:
+            # stop if there are any known issues with the document
+            self.report(
+                "Aborting: the document contains content that cannot be "
+                "cut as-is (see the warning(s) above). Nothing has been "
+                "sent to the cutter. Fix the document and try again.",
+                'error')
+            return
+
         if self.options.toolholder is not None:
             self.options.toolholder = int(self.options.toolholder)
         self.pen=None


### PR DESCRIPTION
`sendto_silhouette` already collects warnings on unconverted objects like text. But those are currently only displayed a the end of the job and do not prevent the job from running.

This can result in having a partial plot only and loosing material. 

This PR changes the behavior so only if there are no warning, the job proceeds.