### PR TITLE
Add multi-page SVG support

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -28,7 +28,7 @@ As a result the cut will go precisely along the graphics.
 1. Set mark to mark distance or clear it to zero if autocalculating from document size
 1. Press Apply
 
-This will create a new layer called `Regmarks` with the newly generated registration mark.
+This will create a new layer called `Regmarks` with the newly generated registration mark. In a multi-page document, it creates one `Regmarks (page N)` layer on every page.
 
 On the bottom will also be a string shown below that would remind you what settings this was generated with.
 - `mark distance from document: Left=10.0mm, Top=10.0mm; mark to mark distance: X=190.0mm, Y=277.0mm;`

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -142,17 +142,7 @@ class InsertRegmark(EffectExtension):
 
 	def regmark_ids(self, page_index, page_count):
 		"""Keep single-page IDs stable and make multi-page IDs unique."""
-		if page_count == 1:
-			return {
-				"layer": REGMARK_LAYER_ID,
-				"top_left": REGMARK_TOP_LEFT_ID,
-				"top_right": REGMARK_TOP_RIGHT_ID,
-				"bottom_left": REGMARK_BOTTOM_LEFT_ID,
-				"bottom_right": REGMARK_BOTTOM_RIGHT_ID,
-				"safe_area": REGMARK_SAFE_AREA_ID,
-				"notes": REGMARK_NOTES_ID,
-			}
-		suffix = "-page-" + str(page_index + 1)
+		suffix = "" if page_count == 1 else "-page-" + str(page_index + 1)
 		return {
 			"layer": REGMARK_LAYER_ID + suffix,
 			"top_left": REGMARK_TOP_LEFT_ID + suffix,

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -144,7 +144,6 @@ class InsertRegmark(EffectExtension):
 		"""Keep single-page IDs stable and make multi-page IDs unique."""
 		suffix = "" if page_count == 1 else "-page-" + str(page_index + 1)
 		return {
-			"layer": REGMARK_LAYER_ID + suffix,
 			"top_left": REGMARK_TOP_LEFT_ID + suffix,
 			"top_right": REGMARK_TOP_RIGHT_ID + suffix,
 			"bottom_left": REGMARK_BOTTOM_LEFT_ID + suffix,
@@ -153,7 +152,7 @@ class InsertRegmark(EffectExtension):
 			"notes": REGMARK_NOTES_ID + suffix,
 		}
 
-	def render_page_regmarks(self, page, page_index, page_count):
+	def render_page_regmarks(self, page, page_index, page_count, regmark_layer, mm_to_user_unit):
 		"""Render one page's registration marks in its local coordinates."""
 		reg_origin_X = self.options.regoriginx
 		reg_origin_Y = self.options.regoriginy
@@ -172,28 +171,30 @@ class InsertRegmark(EffectExtension):
 			self.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
 			self.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
-		mm_to_user_unit = self.svg.viewport_to_unit('1mm')
-		layer_name = REGMARK_LAYERNAME
+		mark_group = regmark_layer
 		if page_count > 1:
-			layer_name += " (page " + str(page_index + 1) + ")"
-		regmark_layer = Layer.new(layer_name, id=ids["layer"])
-		regmark_layer.transform = (
-			Transform(translate=(page["x"], page["y"])) @
-			Transform(scale=mm_to_user_unit)
-		)
+			mark_group = Group.new(
+				REGMARK_LAYERNAME + " (page " + str(page_index + 1) + ")",
+				id=REGMARK_LAYER_ID + "-page-" + str(page_index + 1),
+			)
+			mark_group.transform = (
+				Transform(translate=(page["x"], page["y"])) @
+				Transform(scale=mm_to_user_unit)
+			)
+			regmark_layer.append(mark_group)
 
 		top_right_x = reg_origin_X + reg_width
 		bottom_left_y = reg_origin_Y + reg_length
 
 		if reg_style == REGSTYLE_FOUR_CORNER:
-			regmark_layer.append(self.l_mark(reg_origin_X, reg_origin_Y, +1, +1, ids["top_left"], REG_MARK_LINE_WIDTH_MM))
+			mark_group.append(self.l_mark(reg_origin_X, reg_origin_Y, +1, +1, ids["top_left"], REG_MARK_LINE_WIDTH_MM))
 		else:
-			regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id=ids["top_left"], style='fill:black;'))
+			mark_group.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id=ids["top_left"], style='fill:black;'))
 
-		regmark_layer.append(self.l_mark(top_right_x, reg_origin_Y, -1, +1, ids["top_right"], REG_MARK_LINE_WIDTH_MM))
-		regmark_layer.append(self.l_mark(reg_origin_X, bottom_left_y, +1, -1, ids["bottom_left"], REG_MARK_LINE_WIDTH_MM))
+		mark_group.append(self.l_mark(top_right_x, reg_origin_Y, -1, +1, ids["top_right"], REG_MARK_LINE_WIDTH_MM))
+		mark_group.append(self.l_mark(reg_origin_X, bottom_left_y, +1, -1, ids["bottom_left"], REG_MARK_LINE_WIDTH_MM))
 		if reg_style == REGSTYLE_FOUR_CORNER:
-			regmark_layer.append(self.l_mark(top_right_x, bottom_left_y, -1, -1, ids["bottom_right"], REG_MARK_LINE_WIDTH_MM))
+			mark_group.append(self.l_mark(top_right_x, bottom_left_y, -1, -1, ids["bottom_right"], REG_MARK_LINE_WIDTH_MM))
 
 		safearea_left_x = reg_origin_X + REG_LINE_MM
 		safearea_top_y = reg_origin_Y + REG_LINE_MM
@@ -221,19 +222,24 @@ class InsertRegmark(EffectExtension):
 			(safearea_left_x, safearea_bottom_y),
 			(safearea_left_x - REG_SAFE_AREA_MM, safearea_bottom_y),
 		]
-		regmark_layer.append(PathElement.new(path="M" + str(safe_area_points) + "Z", id=ids["safe_area"], style='fill:white;stroke:none;'))
+		mark_group.append(PathElement.new(path="M" + str(safe_area_points) + "Z", id=ids["safe_area"], style='fill:white;stroke:none;'))
 
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		regmark_layer.append(TextElement(safe_area_note, x=f"{(safearea_left_x + 3)}", y=f"{(safearea_bottom_y + (REG_SAFE_AREA_MM + reg_origin_Y / 2))}", id=ids["notes"], style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PX}px;"))
-
-		regmark_layer.set_sensitive(False)
-		self.svg.insert(0, regmark_layer)
+		mark_group.append(TextElement(safe_area_note, x=f"{(safearea_left_x + 3)}", y=f"{(safearea_bottom_y + (REG_SAFE_AREA_MM + reg_origin_Y / 2))}", id=ids["notes"], style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PX}px;"))
 
 	def effect(self):
 		pages = self.get_document_pages()
 		self.remove_existing_regmark_layers()
+		mm_to_user_unit = self.svg.viewport_to_unit('1mm')
+		regmark_layer = Layer.new(REGMARK_LAYERNAME, id=REGMARK_LAYER_ID)
+		if len(pages) == 1:
+			regmark_layer.transform = Transform(scale=mm_to_user_unit)
 		for page_index, page in enumerate(pages):
-			self.render_page_regmarks(page, page_index, len(pages))
+			self.render_page_regmarks(
+				page, page_index, len(pages), regmark_layer, mm_to_user_unit
+			)
+		regmark_layer.set_sensitive(False)
+		self.svg.insert(0, regmark_layer)
 
 		# Set Page Setting to enable checkerboard (This is required so that safe area is easier to see)
 		self.svg.namedview.set('inkscape:pagecheckerboard', str(ENABLE_CHECKERBOARD).lower())

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -123,11 +123,23 @@ class InsertRegmark(EffectExtension):
 			return pages
 
 		viewbox = self.svg.get_viewbox()
+		if viewbox[2] and viewbox[3]:
+			return [{
+				"x": viewbox[0],
+				"y": viewbox[1],
+				"width": viewbox[2],
+				"height": viewbox[3],
+			}]
+
+		# Inkex 1.1 and 1.2 report a zero-sized viewBox for legacy documents
+		# that specify only width and height.
 		return [{
-			"x": viewbox[0],
-			"y": viewbox[1],
-			"width": viewbox[2],
-			"height": viewbox[3],
+			"x": 0,
+			"y": 0,
+			"width": self.svg.viewport_width,
+			"height": self.svg.viewport_height,
+			"width_mm": self.svg.to_dimensional(self.svg.viewport_width, "mm"),
+			"height_mm": self.svg.to_dimensional(self.svg.viewport_height, "mm"),
 		}]
 
 	def remove_existing_regmark_layers(self):
@@ -156,8 +168,14 @@ class InsertRegmark(EffectExtension):
 		"""Render one page's registration marks in its local coordinates."""
 		reg_origin_X = self.options.regoriginx
 		reg_origin_Y = self.options.regoriginy
-		page_width = self.svg.unit_to_viewport(page["width"], "mm")
-		page_height = self.svg.unit_to_viewport(page["height"], "mm")
+		page_width = (
+			page["width_mm"] if "width_mm" in page
+			else self.svg.unit_to_viewport(page["width"], "mm")
+		)
+		page_height = (
+			page["height_mm"] if "height_mm" in page
+			else self.svg.unit_to_viewport(page["height"], "mm")
+		)
 		reg_width = self.options.regwidth or page_width - reg_origin_X * 2
 		reg_length = self.options.reglength or page_height - reg_origin_Y * 2
 		reg_style = self.options.regstyle

--- a/render_silhouette_regmarks.py
+++ b/render_silhouette_regmarks.py
@@ -97,95 +97,153 @@ class InsertRegmark(EffectExtension):
 		]
 		return PathElement.new(path="M"+str(path), id=mark_id, style=f"fill:none; stroke:black; stroke-width:{line_width};")
 
-	def effect(self):
+	def get_document_pages(self):
+		"""Return Inkscape page rectangles in document viewport coordinates."""
+		namedview = getattr(self.svg, "namedview", None)
+		if namedview is not None and hasattr(namedview, "get_pages"):
+			page_elements = namedview.get_pages()
+		elif namedview is not None:
+			page_elements = [
+				node for node in namedview
+				if isinstance(node.tag, str) and node.tag.endswith("}page")
+			]
+		else:
+			page_elements = []
+
+		pages = [
+			{
+				"x": float(getattr(page, "x", page.get("x", 0))),
+				"y": float(getattr(page, "y", page.get("y", 0))),
+				"width": float(getattr(page, "width", page.get("width", 0))),
+				"height": float(getattr(page, "height", page.get("height", 0))),
+			}
+			for page in page_elements
+		]
+		if pages:
+			return pages
+
+		viewbox = self.svg.get_viewbox()
+		return [{
+			"x": viewbox[0],
+			"y": viewbox[1],
+			"width": viewbox[2],
+			"height": viewbox[3],
+		}]
+
+	def remove_existing_regmark_layers(self):
+		"""Remove renderer-owned layers from prior single- or multi-page runs."""
+		page_prefix = REGMARK_LAYER_ID + "-page-"
+		for element in list(self.svg.iter()):
+			element_id = element.get("id", "")
+			if (element_id == REGMARK_LAYER_ID or
+					(element_id.startswith(page_prefix) and
+					 element_id[len(page_prefix):].isdigit())):
+				element.delete()
+
+	def regmark_ids(self, page_index, page_count):
+		"""Keep single-page IDs stable and make multi-page IDs unique."""
+		if page_count == 1:
+			return {
+				"layer": REGMARK_LAYER_ID,
+				"top_left": REGMARK_TOP_LEFT_ID,
+				"top_right": REGMARK_TOP_RIGHT_ID,
+				"bottom_left": REGMARK_BOTTOM_LEFT_ID,
+				"bottom_right": REGMARK_BOTTOM_RIGHT_ID,
+				"safe_area": REGMARK_SAFE_AREA_ID,
+				"notes": REGMARK_NOTES_ID,
+			}
+		suffix = "-page-" + str(page_index + 1)
+		return {
+			"layer": REGMARK_LAYER_ID + suffix,
+			"top_left": REGMARK_TOP_LEFT_ID + suffix,
+			"top_right": REGMARK_TOP_RIGHT_ID + suffix,
+			"bottom_left": REGMARK_BOTTOM_LEFT_ID + suffix,
+			"bottom_right": REGMARK_BOTTOM_RIGHT_ID + suffix,
+			"safe_area": REGMARK_SAFE_AREA_ID + suffix,
+			"notes": REGMARK_NOTES_ID + suffix,
+		}
+
+	def render_page_regmarks(self, page, page_index, page_count):
+		"""Render one page's registration marks in its local coordinates."""
 		reg_origin_X = self.options.regoriginx
 		reg_origin_Y = self.options.regoriginy
-		reg_width = self.options.regwidth or self.svg.to_dimensional(self.svg.viewport_width, "mm") - reg_origin_X * 2
-		reg_length = self.options.reglength or self.svg.to_dimensional(self.svg.viewport_height, "mm") - reg_origin_Y * 2
+		page_width = self.svg.unit_to_viewport(page["width"], "mm")
+		page_height = self.svg.unit_to_viewport(page["height"], "mm")
+		reg_width = self.options.regwidth or page_width - reg_origin_X * 2
+		reg_length = self.options.reglength or page_height - reg_origin_Y * 2
 		reg_style = self.options.regstyle
+		ids = self.regmark_ids(page_index, page_count)
 
 		if self.options.verbose == True:
-			self.msg(gettext("[INFO]: page width ")+str(self.svg.to_dimensional(self.svg.viewport_width, "mm")))
-			self.msg(gettext("[INFO]: page height ")+str(self.svg.to_dimensional(self.svg.viewport_height, "mm")))
+			self.msg(gettext("[INFO]: page width ")+str(page_width))
+			self.msg(gettext("[INFO]: page height ")+str(page_height))
 			self.msg(gettext("[INFO]: regmark from document left ")+str(reg_origin_X))
 			self.msg(gettext("[INFO]: regmark from document top ")+str(reg_origin_Y))
 			self.msg(gettext("[INFO]: regmark to regmark spacing X ")+str(reg_width))
 			self.msg(gettext("[INFO]: regmark to regmark spacing Y ")+str(reg_length))
 
-		# Check if existing regmark layer exist and delete it
-		old_regmark_layer = self.svg.getElementById(REGMARK_LAYER_ID)
-		if old_regmark_layer is not None:
-			old_regmark_layer.delete()
-
-		# Register Mark #
 		mm_to_user_unit = self.svg.viewport_to_unit('1mm')
+		layer_name = REGMARK_LAYERNAME
+		if page_count > 1:
+			layer_name += " (page " + str(page_index + 1) + ")"
+		regmark_layer = Layer.new(layer_name, id=ids["layer"])
+		regmark_layer.transform = (
+			Transform(translate=(page["x"], page["y"])) @
+			Transform(scale=mm_to_user_unit)
+		)
 
-		# Create a new register mark layer
-		regmark_layer = Layer.new(REGMARK_LAYERNAME, id=REGMARK_LAYER_ID)
-		regmark_layer.transform = Transform(scale=mm_to_user_unit)
+		top_right_x = reg_origin_X + reg_width
+		bottom_left_y = reg_origin_Y + reg_length
 
-		top_right_x = reg_origin_X+reg_width
-		bottom_left_y = reg_origin_Y+reg_length
-
-		# Top left corner: a filled square for the standard style, or an L-shaped
-		# mark for the four-corner style (which uses four matching corner marks).
 		if reg_style == REGSTYLE_FOUR_CORNER:
-			regmark_layer.append(self.l_mark(reg_origin_X, reg_origin_Y, +1, +1, REGMARK_TOP_LEFT_ID, REG_MARK_LINE_WIDTH_MM))
+			regmark_layer.append(self.l_mark(reg_origin_X, reg_origin_Y, +1, +1, ids["top_left"], REG_MARK_LINE_WIDTH_MM))
 		else:
-			regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id=REGMARK_TOP_LEFT_ID, style='fill:black;'))
+			regmark_layer.append(Rectangle.new(left=reg_origin_X, top=reg_origin_Y, width=REG_SQUARE_MM, height=REG_SQUARE_MM, id=ids["top_left"], style='fill:black;'))
 
-		# Create horizontal and vertical lines for top right corner
-		regmark_layer.append(self.l_mark(top_right_x, reg_origin_Y, -1, +1, REGMARK_TOP_RIGHT_ID, REG_MARK_LINE_WIDTH_MM))
-
-		# Create horizontal and vertical lines for bottom left corner
-		regmark_layer.append(self.l_mark(reg_origin_X, bottom_left_y, +1, -1, REGMARK_BOTTOM_LEFT_ID, REG_MARK_LINE_WIDTH_MM))
-
-		# The four-corner style additionally uses a fourth L-shaped mark in the bottom right corner
+		regmark_layer.append(self.l_mark(top_right_x, reg_origin_Y, -1, +1, ids["top_right"], REG_MARK_LINE_WIDTH_MM))
+		regmark_layer.append(self.l_mark(reg_origin_X, bottom_left_y, +1, -1, ids["bottom_left"], REG_MARK_LINE_WIDTH_MM))
 		if reg_style == REGSTYLE_FOUR_CORNER:
-			regmark_layer.append(self.l_mark(top_right_x, bottom_left_y, -1, -1, REGMARK_BOTTOM_RIGHT_ID, REG_MARK_LINE_WIDTH_MM))
+			regmark_layer.append(self.l_mark(top_right_x, bottom_left_y, -1, -1, ids["bottom_right"], REG_MARK_LINE_WIDTH_MM))
 
-		# Safe Area Marker #
-		# This draws the safe drawing area
-		safearea_left_x = reg_origin_X+REG_LINE_MM
-		safearea_top_y = reg_origin_Y+REG_LINE_MM
-		safearea_right_x = reg_origin_X+reg_width-REG_LINE_MM
-		safearea_bottom_y = reg_origin_Y+reg_length-REG_LINE_MM
+		safearea_left_x = reg_origin_X + REG_LINE_MM
+		safearea_top_y = reg_origin_Y + REG_LINE_MM
+		safearea_right_x = reg_origin_X + reg_width - REG_LINE_MM
+		safearea_bottom_y = reg_origin_Y + reg_length - REG_LINE_MM
 		if reg_style == REGSTYLE_FOUR_CORNER:
-			# Notch the safe area around the fourth (bottom right) mark, just like
-			# the other three corners, so its stroke is not partially covered.
 			bottom_right_corner = [
-				(safearea_right_x+REG_SAFE_AREA_MM,safearea_bottom_y),
-				(safearea_right_x,safearea_bottom_y),
-				(safearea_right_x,safearea_bottom_y+REG_SAFE_AREA_MM),
+				(safearea_right_x + REG_SAFE_AREA_MM, safearea_bottom_y),
+				(safearea_right_x, safearea_bottom_y),
+				(safearea_right_x, safearea_bottom_y + REG_SAFE_AREA_MM),
 			]
 		else:
-			# Standard style has no bottom right mark, so keep the corner square.
 			bottom_right_corner = [
-				(safearea_right_x+REG_SAFE_AREA_MM,safearea_bottom_y+REG_SAFE_AREA_MM),
+				(safearea_right_x + REG_SAFE_AREA_MM, safearea_bottom_y + REG_SAFE_AREA_MM),
 			]
 		safe_area_points = [
-			(safearea_left_x-REG_SAFE_AREA_MM,safearea_top_y),
-			(safearea_left_x,safearea_top_y),
-			(safearea_left_x,safearea_top_y-REG_SAFE_AREA_MM),
-			(safearea_right_x,safearea_top_y-REG_SAFE_AREA_MM),
-			(safearea_right_x,safearea_top_y),
-			(safearea_right_x+REG_SAFE_AREA_MM,safearea_top_y),
+			(safearea_left_x - REG_SAFE_AREA_MM, safearea_top_y),
+			(safearea_left_x, safearea_top_y),
+			(safearea_left_x, safearea_top_y - REG_SAFE_AREA_MM),
+			(safearea_right_x, safearea_top_y - REG_SAFE_AREA_MM),
+			(safearea_right_x, safearea_top_y),
+			(safearea_right_x + REG_SAFE_AREA_MM, safearea_top_y),
 		] + bottom_right_corner + [
-			(safearea_left_x,safearea_bottom_y+REG_SAFE_AREA_MM),
-			(safearea_left_x,safearea_bottom_y),
-			(safearea_left_x-REG_SAFE_AREA_MM,safearea_bottom_y),
+			(safearea_left_x, safearea_bottom_y + REG_SAFE_AREA_MM),
+			(safearea_left_x, safearea_bottom_y),
+			(safearea_left_x - REG_SAFE_AREA_MM, safearea_bottom_y),
 		]
-		regmark_layer.append(PathElement.new(path="M"+str(safe_area_points)+"Z", id=REGMARK_SAFE_AREA_ID, style='fill:white;stroke:none;'))
+		regmark_layer.append(PathElement.new(path="M" + str(safe_area_points) + "Z", id=ids["safe_area"], style='fill:white;stroke:none;'))
 
-		# Add some settings reminders to the print layer as a reminder
 		safe_area_note = f"mark distance from document: Left={reg_origin_X}mm, Top={reg_origin_Y}mm; mark to mark distance: X={reg_width}mm, Y={reg_length}mm; "
-		regmark_layer.append(TextElement(safe_area_note, x=f"{(safearea_left_x+3)}", y=f"{(safearea_bottom_y+(REG_SAFE_AREA_MM+reg_origin_Y/2))}", id = REGMARK_NOTES_ID, style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PX}px;"))
+		regmark_layer.append(TextElement(safe_area_note, x=f"{(safearea_left_x + 3)}", y=f"{(safearea_bottom_y + (REG_SAFE_AREA_MM + reg_origin_Y / 2))}", id=ids["notes"], style=f"font-size:{REG_MARK_INFO_FONT_SIZE_PX}px;"))
 
-		# Lock Layer
 		regmark_layer.set_sensitive(False)
-
-		# Insert regmark layer to the bottom of the svg layer stack to avoid covering any existing artwork
 		self.svg.insert(0, regmark_layer)
+
+	def effect(self):
+		pages = self.get_document_pages()
+		self.remove_existing_regmark_layers()
+		for page_index, page in enumerate(pages):
+			self.render_page_regmarks(page, page_index, len(pages))
 
 		# Set Page Setting to enable checkerboard (This is required so that safe area is easier to see)
 		self.svg.namedview.set('inkscape:pagecheckerboard', str(ENABLE_CHECKERBOARD).lower())

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -799,6 +799,12 @@ class SendtoSilhouette(EffectExtension):
                 continue
             if not group.label or "regmark" not in group.label.lower():
                 continue
+            if (group.get("id") == REGMARK_LAYER_ID and any(
+                    child.get("id", "").startswith(REGMARK_LAYER_ID + "-page-")
+                    for child in group)):
+                # Multi-page marks live in page-specific groups inside this
+                # common layer; inspect the page group, not their union.
+                continue
             parent = group.getparent()
             parent_transform = (
                 parent.composed_transform()

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -511,13 +511,30 @@ class SendtoSilhouette(EffectExtension):
 
         if not pages:
             viewbox = self.svg.get_viewbox()
-            pages.append({
-                "id": None,
-                "x": viewbox[0],
-                "y": viewbox[1],
-                "width": viewbox[2],
-                "height": viewbox[3],
-            })
+            if viewbox[2] and viewbox[3]:
+                pages.append({
+                    "id": None,
+                    "x": viewbox[0],
+                    "y": viewbox[1],
+                    "width": viewbox[2],
+                    "height": viewbox[3],
+                })
+            else:
+                # Inkex 1.1 and 1.2 report a zero-sized viewBox for legacy
+                # documents that specify only width and height.
+                pages.append({
+                    "id": None,
+                    "x": 0,
+                    "y": 0,
+                    "width": self.svg.viewport_width,
+                    "height": self.svg.viewport_height,
+                    "width_mm": self.svg.to_dimensional(
+                        self.svg.viewport_width, "mm"
+                    ),
+                    "height_mm": self.svg.to_dimensional(
+                        self.svg.viewport_height, "mm"
+                    ),
+                })
 
         self.document_pages = pages
         return pages
@@ -566,8 +583,12 @@ class SendtoSilhouette(EffectExtension):
         self.active_page_indices = used
 
         sizes = [(
-            self.svg.unit_to_viewport(pages[index]["width"], "mm"),
-            self.svg.unit_to_viewport(pages[index]["height"], "mm"),
+            pages[index]["width_mm"]
+            if "width_mm" in pages[index]
+            else self.svg.unit_to_viewport(pages[index]["width"], "mm"),
+            pages[index]["height_mm"]
+            if "height_mm" in pages[index]
+            else self.svg.unit_to_viewport(pages[index]["height"], "mm"),
         ) for index in used]
         first_width, first_height = sizes[0]
         if any(abs(width - first_width) > 0.01 or

--- a/sendto_silhouette.py
+++ b/sendto_silhouette.py
@@ -8,7 +8,7 @@
 __version__ = "1.29"     # Keep in sync with sendto_silhouette.inx ca line 179
 __author__ = "Juergen Weigert <juergen@fabmail.org> and contributors"
 
-import sys, os, time, math, operator, subprocess
+import sys, os, time, math, operator, re, subprocess
 
 # we sys.path.append() the directory where this script lives.
 sys.path.append(os.path.dirname(os.path.abspath(sys.argv[0])))
@@ -117,9 +117,14 @@ class SendtoSilhouette(EffectExtension):
         self.warnings = {}
         self.pathcount = 0
         self.paths = []
+        self.path_page_indices = []
         self.docTransform = Transform()
         self.cmdfile = None
         self.caffeinate_process = None
+        self.document_pages = None
+        self.active_page_indices = []
+        self.media_width_mm = None
+        self.media_height_mm = None
 
         self.doc_reg_x = 0
         self.doc_reg_y = 0
@@ -460,7 +465,7 @@ class SendtoSilhouette(EffectExtension):
         )
 
 
-    def plotPath(self, path: Path):
+    def plotPath(self, path: Path, page_index=None):
         """
         Plot the path after smoothing curves to straights
         """
@@ -475,6 +480,113 @@ class SendtoSilhouette(EffectExtension):
             # extract path
             if len(sp) > 1:
                 self.paths.append([tuple(csp[1]) for csp in sp])
+                self.path_page_indices.append(page_index)
+
+
+    def get_document_pages(self):
+        """Return Inkscape page rectangles in document viewport coordinates."""
+        if self.document_pages is not None:
+            return self.document_pages
+
+        pages = []
+        namedview = getattr(self.svg, "namedview", None)
+        if namedview is not None and hasattr(namedview, "get_pages"):
+            page_elements = namedview.get_pages()
+        elif namedview is not None:
+            page_elements = [
+                node for node in namedview
+                if isinstance(node.tag, str) and node.tag.endswith("}page")
+            ]
+        else:
+            page_elements = []
+
+        for page in page_elements:
+            pages.append({
+                "id": page.get("id"),
+                "x": float(getattr(page, "x", page.get("x", 0))),
+                "y": float(getattr(page, "y", page.get("y", 0))),
+                "width": float(getattr(page, "width", page.get("width", 0))),
+                "height": float(getattr(page, "height", page.get("height", 0))),
+            })
+
+        if not pages:
+            viewbox = self.svg.get_viewbox()
+            pages.append({
+                "id": None,
+                "x": viewbox[0],
+                "y": viewbox[1],
+                "width": viewbox[2],
+                "height": viewbox[3],
+            })
+
+        self.document_pages = pages
+        return pages
+
+
+    def page_index_for_bbox(self, bbox):
+        """Find the page containing a document-coordinate bounding box."""
+        if bbox is None:
+            return None
+
+        left, right = bbox.left, bbox.right
+        top, bottom = bbox.top, bbox.bottom
+        center_x = (left + right) / 2
+        center_y = (top + bottom) / 2
+        pages = self.get_document_pages()
+
+        # The center is stable for paths touching a page edge or having no area.
+        for index, page in enumerate(pages):
+            if (page["x"] <= center_x <= page["x"] + page["width"] and
+                    page["y"] <= center_y <= page["y"] + page["height"]):
+                return index
+
+        # For an object crossing a page edge, use the page with the largest
+        # intersection. Objects entirely on the canvas remain document-global.
+        best_index = None
+        best_overlap = 0
+        for index, page in enumerate(pages):
+            overlap_x = max(0, min(right, page["x"] + page["width"]) -
+                            max(left, page["x"]))
+            overlap_y = max(0, min(bottom, page["y"] + page["height"]) -
+                            max(top, page["y"]))
+            overlap = overlap_x * overlap_y
+            if overlap > best_overlap:
+                best_index = index
+                best_overlap = overlap
+        return best_index
+
+
+    def sync_page_settings(self):
+        """Select media geometry from the pages containing the cut paths."""
+        pages = self.get_document_pages()
+        used = sorted({index for index in self.path_page_indices
+                       if index is not None})
+        if not used:
+            used = [0]
+        self.active_page_indices = used
+
+        sizes = [(
+            self.svg.unit_to_viewport(pages[index]["width"], "mm"),
+            self.svg.unit_to_viewport(pages[index]["height"], "mm"),
+        ) for index in used]
+        first_width, first_height = sizes[0]
+        if any(abs(width - first_width) > 0.01 or
+               abs(height - first_height) > 0.01
+               for width, height in sizes[1:]):
+            raise ValueError(
+                "Selected paths span pages with different sizes. "
+                "Send one page size at a time."
+            )
+
+        self.media_width_mm = first_width
+        self.media_height_mm = first_height
+        page_names = ", ".join(
+            pages[index]["id"] or str(index + 1) for index in used
+        )
+        self.report(
+            f"Using page-local coordinates for page(s) {page_names}: "
+            f"{first_width:g} x {first_height:g} mm", "log"
+        )
 
 
     def recursivelyTraverseSvg(self, aNodeList,
@@ -550,10 +662,6 @@ class SendtoSilhouette(EffectExtension):
             elif isinstance(node, (PathElement, Rectangle, Circle, Ellipse, Line, Polyline, Polygon)):
                 if v == "hidden" or v == "collapse":
                     continue
-                # calculate this object's transform
-                # NOTE: <<< transforms operate from right (detail) to left (whole)
-                transform = self.docTransform @ my_transform
-
                 # convert element to path
                 node = node.to_path_element()
 
@@ -561,8 +669,23 @@ class SendtoSilhouette(EffectExtension):
                 if self.options.dashes:
                     convert2dash(node)
 
+                # Resolve the page after applying the element's complete SVG
+                # transform, but before converting viewport units to mm. In a
+                # multi-page Inkscape document, page 2+ objects retain their
+                # canvas offset unless it is explicitly removed here.
+                document_path = node.path.transform(my_transform)
+                page_index = self.page_index_for_bbox(document_path.bounding_box())
+                page_transform = Transform()
+                if page_index is not None:
+                    page = self.get_document_pages()[page_index]
+                    page_transform = Transform(
+                        translate=(-page["x"], -page["y"])
+                    )
+
+                # NOTE: <<< transforms operate from right (detail) to left (whole)
+                transform = self.docTransform @ page_transform
                 self.pathcount += 1
-                self.plotPath(node.path.transform(transform))
+                self.plotPath(document_path.transform(transform), page_index)
 
             elif isinstance(node, TextElement):
                 texts = []
@@ -616,6 +739,95 @@ class SendtoSilhouette(EffectExtension):
         self.report(f"8 svg.viewport_width = {self.svg.viewport_width}", 'tty')
         self.docTransform = Transform(scale=(self.svg._base_scale("mm")))
 
+    def regmark_settings_from_group(self, group, page_index):
+        """Read and validate renderer metadata from one page's regmark layer."""
+        notes = " ".join(
+            "".join(node.itertext())
+            for node in group.iter()
+            if isinstance(node, TextElement)
+        )
+        match = re.search(
+            r"Left\s*=\s*([-+0-9.eE]+)\s*mm.*?"
+            r"Top\s*=\s*([-+0-9.eE]+)\s*mm.*?"
+            r"X\s*=\s*([-+0-9.eE]+)\s*mm.*?"
+            r"Y\s*=\s*([-+0-9.eE]+)\s*mm",
+            notes,
+            re.DOTALL,
+        )
+        if match is None:
+            return None
+        settings = tuple(float(value) for value in match.groups())
+
+        page = self.get_document_pages()[page_index]
+        marker_boxes = []
+        marker_types = (PathElement, Rectangle, Circle, Ellipse,
+                        Line, Polyline, Polygon)
+        for node in group.iter():
+            if not isinstance(node, marker_types):
+                continue
+            bbox = node.bounding_box(transform=True)
+            if bbox is None:
+                continue
+            left = self.svg.unit_to_viewport(bbox.left - page["x"], "mm")
+            right = self.svg.unit_to_viewport(bbox.right - page["x"], "mm")
+            top = self.svg.unit_to_viewport(bbox.top - page["y"], "mm")
+            bottom = self.svg.unit_to_viewport(bbox.bottom - page["y"], "mm")
+            # Exclude the large safe-area shape, which touches every corner.
+            if right - left <= 40 and bottom - top <= 40:
+                marker_boxes.append((left, right, top, bottom))
+
+        origin_x, origin_y, width, length = settings
+        required_points = (
+            (origin_x, origin_y),
+            (origin_x + width, origin_y),
+            (origin_x, origin_y + length),
+        )
+        tolerance = 1.0
+        for x, y in required_points:
+            if not any(
+                left - tolerance <= x <= right + tolerance and
+                top - tolerance <= y <= bottom + tolerance
+                for left, right, top, bottom in marker_boxes
+            ):
+                return None
+        return settings
+
+    def page_regmark_settings(self, page_index):
+        """Find registration marks belonging to a specific Inkscape page."""
+        for group in self.svg.iter():
+            if not isinstance(group, Group):
+                continue
+            if not group.label or "regmark" not in group.label.lower():
+                continue
+            parent = group.getparent()
+            parent_transform = (
+                parent.composed_transform()
+                if hasattr(parent, "composed_transform") else Transform()
+            )
+            if self.page_index_for_bbox(group.bounding_box(parent_transform)) != page_index:
+                continue
+            settings = self.regmark_settings_from_group(group, page_index)
+            if settings is not None:
+                return settings
+
+        # Compatibility fallback for older generated files without notes.
+        top_left = self.svg.getElementById(REGMARK_TOP_LEFT_ID)
+        top_right = self.svg.getElementById(REGMARK_TOP_RIGHT_ID)
+        bottom_left = self.svg.getElementById(REGMARK_BOTTOM_LEFT_ID)
+        if top_left is None or top_right is None or bottom_left is None:
+            return None
+        tl_bbox = top_left.bounding_box(transform=True)
+        tr_bbox = top_right.bounding_box(transform=True)
+        bl_bbox = bottom_left.bounding_box(transform=True)
+        if self.page_index_for_bbox(tl_bbox) != page_index:
+            return None
+        page = self.get_document_pages()[page_index]
+        origin_x = self.svg.unit_to_viewport(tl_bbox.left - page["x"], "mm")
+        origin_y = self.svg.unit_to_viewport(tl_bbox.top - page["y"], "mm")
+        width = self.svg.unit_to_viewport(tr_bbox.right - page["x"], "mm") - origin_x
+        length = self.svg.unit_to_viewport(bl_bbox.bottom - page["y"], "mm") - origin_y
+        return origin_x, origin_y, width, length
+
     def detect_doc_regmark(self):
         """
         This scans the svg document for svg element relating to an autogenerated registration mark
@@ -627,18 +839,24 @@ class SendtoSilhouette(EffectExtension):
         self.doc_reg_y = 0
         self.doc_reg_width = 0
         self.doc_reg_length = 0
-        # Check if all expected regmark svg elements is present
-        if self.svg.getElementById(REGMARK_TOP_LEFT_ID) is None:
-            return
-        if self.svg.getElementById(REGMARK_TOP_RIGHT_ID) is None:
-            return
-        if self.svg.getElementById(REGMARK_BOTTOM_LEFT_ID) is None:
-            return
-        # Calculate and derive the expected registration mark offsets
-        self.doc_reg_x = self.svg.unit_to_viewport(self.svg.getElementById(REGMARK_TOP_LEFT_ID).bounding_box(transform=True).left, "mm")
-        self.doc_reg_y = self.svg.unit_to_viewport(self.svg.getElementById(REGMARK_TOP_LEFT_ID).bounding_box(transform=True).top, "mm")
-        self.doc_reg_width = self.svg.unit_to_viewport(self.svg.getElementById(REGMARK_TOP_RIGHT_ID).bounding_box(transform=True).right, "mm") - self.doc_reg_x
-        self.doc_reg_length = self.svg.unit_to_viewport(self.svg.getElementById(REGMARK_BOTTOM_LEFT_ID).bounding_box(transform=True).bottom, "mm") - self.doc_reg_y
+        page_indices = self.active_page_indices or [0]
+        page_settings = []
+        for page_index in page_indices:
+            settings = self.page_regmark_settings(page_index)
+            if settings is None:
+                return
+            page_settings.append(settings)
+
+        first = page_settings[0]
+        if any(any(abs(actual - expected) > 0.01
+                   for actual, expected in zip(settings, first))
+               for settings in page_settings[1:]):
+            raise ValueError(
+                "Selected Print & Cut paths span pages with different "
+                "registration-mark geometry. Send one page at a time."
+            )
+        (self.doc_reg_x, self.doc_reg_y,
+         self.doc_reg_width, self.doc_reg_length) = first
         self.report(f"Detected Existing Registration Mark:: mark distance from document: Left={self.doc_reg_x}mm, Top={self.doc_reg_y}mm; mark to mark distance: X={self.doc_reg_width}mm, Y={self.doc_reg_length}mm;", 'log')
 
     def sync_regmark_settings(self):
@@ -649,8 +867,10 @@ class SendtoSilhouette(EffectExtension):
         self.detect_doc_regmark()
         self.reg_origin_X = self.options.regoriginx or self.doc_reg_x
         self.reg_origin_Y = self.options.regoriginy or self.doc_reg_y
-        self.reg_width    = self.options.regwidth or self.doc_reg_width or self.svg.to_dimensional(self.svg.viewport_width, "mm") - self.reg_origin_X * 2
-        self.reg_length   = self.options.reglength or self.doc_reg_length or self.svg.to_dimensional(self.svg.viewport_height, "mm") - self.reg_origin_Y * 2
+        media_width = self.media_width_mm or convert_unit(self.svg.viewport_width, "mm")
+        media_height = self.media_height_mm or convert_unit(self.svg.viewport_height, "mm")
+        self.reg_width    = self.options.regwidth or self.doc_reg_width or media_width - self.reg_origin_X * 2
+        self.reg_length   = self.options.reglength or self.doc_reg_length or media_height - self.reg_origin_Y * 2
         self.report(f"Using Registration Mark:: mark distance from document: Left={self.reg_origin_X}mm, Top={self.reg_origin_Y}mm; mark to mark distance: X={self.reg_width}mm, Y={self.reg_length}mm;", 'log')
 
     @staticmethod
@@ -804,9 +1024,6 @@ class SendtoSilhouette(EffectExtension):
             self.report_bluetooth_scan()
             return
 
-        # Registration Mark Selection/Calcuation
-        self.sync_regmark_settings()
-
         # Init docTransform
         self.initDocScale()
 
@@ -827,6 +1044,12 @@ class SendtoSilhouette(EffectExtension):
                 "sent to the cutter. Fix the document and try again.",
                 'error')
             return
+
+        # Multi-page documents use canvas-global coordinates. Paths have now
+        # been assigned to pages and normalized, so page-specific media and
+        # registration geometry can be selected safely.
+        self.sync_page_settings()
+        self.sync_regmark_settings()
 
         if self.options.toolholder is not None:
             self.options.toolholder = int(self.options.toolholder)
@@ -956,8 +1179,8 @@ class SendtoSilhouette(EffectExtension):
         if self.options.autocrop:
             # this takes much longer, if we have a complext drawing
             bbox = dev.plot(pathlist=cut,
-                    mediawidth=convert_unit(self.svg.viewport_width, "mm"),
-                    mediaheight=convert_unit(self.svg.viewport_height, "mm"),
+                    mediawidth=self.media_width_mm,
+                    mediaheight=self.media_height_mm,
                     margintop=0,
                     marginleft=0,
                     bboxonly=None,         # only return the bbox, do not draw it.
@@ -981,8 +1204,8 @@ class SendtoSilhouette(EffectExtension):
                     self.options.y_off -= bbox["bbox"]["ury"]*bbox["unit"]
 
         bbox = dev.plot(pathlist=cut,
-            mediawidth=convert_unit(self.svg.viewport_width, "mm"),
-            mediaheight=convert_unit(self.svg.viewport_height, "mm"),
+            mediawidth=self.media_width_mm,
+            mediaheight=self.media_height_mm,
             offset=(self.options.x_off, self.options.y_off),
             bboxonly=self.options.bboxonly,
             endposition=self.options.endposition,

--- a/test/data/multipage_pages.svg
+++ b/test/data/multipage_pages.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+  width="210mm"
+  height="297mm"
+  viewBox="0 0 420 594">
+  <sodipodi:namedview id="namedview1">
+    <inkscape:page x="0" y="0" width="420" height="594" id="page1" />
+    <inkscape:page x="440" y="0" width="420" height="594" id="page2" />
+  </sodipodi:namedview>
+</svg>

--- a/test/data/multipage_regmarks.svg
+++ b/test/data/multipage_regmarks.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:svg="http://www.w3.org/2000/svg"
+  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+  width="210mm"
+  height="297mm"
+  viewBox="0 0 420 594">
+  <sodipodi:namedview id="namedview1">
+    <inkscape:page x="0" y="0" width="420" height="594" id="page1" />
+    <inkscape:page x="440" y="0" width="420" height="594" id="page2" />
+  </sodipodi:namedview>
+  <g inkscape:groupmode="layer" inkscape:label="Regmarks" transform="scale(2)">
+    <path d="M 30,10 H 10 V 30" />
+    <path d="M 180,10 H 200 V 30" />
+    <path d="M 30,287 H 10 V 267" />
+    <text x="33" y="292">mark distance from document: Left=10mm, Top=10mm; mark to mark distance: X=190mm, Y=277mm;</text>
+  </g>
+  <g inkscape:groupmode="layer" inkscape:label="Regmarks copy" transform="matrix(2,0,0,2,440,0)">
+    <path d="M 30,10 H 10 V 30" />
+    <path d="M 180,10 H 200 V 30" />
+    <path d="M 30,287 H 10 V 267" />
+    <text x="33" y="292">mark distance from document: Left=10mm, Top=10mm; mark to mark distance: X=190mm, Y=277mm;</text>
+  </g>
+  <path id="page1-cut" d="M 40,80 H 80 V 120 H 40 Z" />
+  <path id="page2-cut" transform="translate(440,0)" d="M 40,80 H 80 V 120 H 40 Z" />
+</svg>

--- a/test/test_render_silhouette_regmark.py
+++ b/test/test_render_silhouette_regmark.py
@@ -128,3 +128,37 @@ class FourCornerRegmarkTest(InsertRegmarkTest):
                 "mm"),
             300
         )
+
+
+class MultiPageRegmarkTest(InsertRegmarkTest):
+    source_file = "multipage_pages.svg"
+
+    def setUp(self):
+        super().setUp()
+        self.e.parse_arguments([self.data_file(self.source_file)])
+        self.e.load_raw()
+        self.e.effect()
+        self.e.clean_up()
+
+    def test_regmarks_are_created_on_each_page(self):
+        page_one_layer = self.e.svg.getElementById("regmark-page-1")
+        page_two_layer = self.e.svg.getElementById("regmark-page-2")
+        self.assertEqual(page_one_layer.label, "Regmarks (page 1)")
+        self.assertEqual(page_two_layer.label, "Regmarks (page 2)")
+
+        self.assertEqual(
+            self.e.svg.getElementById("regmark-tl-page-1").bounding_box(transform=True),
+            BoundingBox((20.0, 30.0), (20.0, 30.0)),
+        )
+        self.assertEqual(
+            self.e.svg.getElementById("regmark-tl-page-2").bounding_box(transform=True),
+            BoundingBox((460.0, 470.0), (20.0, 30.0)),
+        )
+
+    def test_regenerating_marks_replaces_every_page_layer(self):
+        self.e.effect()
+        layer_ids = [
+            element.get("id") for element in self.e.svg
+            if element.get("id", "").startswith("regmark-page-")
+        ]
+        self.assertEqual(layer_ids, ["regmark-page-2", "regmark-page-1"])

--- a/test/test_render_silhouette_regmark.py
+++ b/test/test_render_silhouette_regmark.py
@@ -141,10 +141,20 @@ class MultiPageRegmarkTest(InsertRegmarkTest):
         self.e.clean_up()
 
     def test_regmarks_are_created_on_each_page(self):
-        page_one_layer = self.e.svg.getElementById("regmark-page-1")
-        page_two_layer = self.e.svg.getElementById("regmark-page-2")
-        self.assertEqual(page_one_layer.label, "Regmarks (page 1)")
-        self.assertEqual(page_two_layer.label, "Regmarks (page 2)")
+        regmark_layer = self.e.svg.getElementById(REGMARK_LAYER_ID)
+        self.assertEqual(regmark_layer.label, REGMARK_LAYERNAME)
+        self.assertEqual(
+            [element.get("id") for element in regmark_layer],
+            ["regmark-page-1", "regmark-page-2"],
+        )
+        self.assertEqual(
+            self.e.svg.getElementById("regmark-page-1").label,
+            "Regmarks (page 1)",
+        )
+        self.assertEqual(
+            self.e.svg.getElementById("regmark-page-2").label,
+            "Regmarks (page 2)",
+        )
 
         self.assertEqual(
             self.e.svg.getElementById("regmark-tl-page-1").bounding_box(transform=True),
@@ -157,8 +167,12 @@ class MultiPageRegmarkTest(InsertRegmarkTest):
 
     def test_regenerating_marks_replaces_every_page_layer(self):
         self.e.effect()
-        layer_ids = [
+        page_group_ids = [
             element.get("id") for element in self.e.svg
-            if element.get("id", "").startswith("regmark-page-")
+            if element.get("id") == REGMARK_LAYER_ID
         ]
-        self.assertEqual(layer_ids, ["regmark-page-2", "regmark-page-1"])
+        self.assertEqual(page_group_ids, [REGMARK_LAYER_ID])
+        self.assertEqual(
+            [element.get("id") for element in self.e.svg.getElementById(REGMARK_LAYER_ID)],
+            ["regmark-page-1", "regmark-page-2"],
+        )

--- a/test/test_sendto_silhouette.py
+++ b/test/test_sendto_silhouette.py
@@ -6,6 +6,7 @@ import subprocess
 from unittest import mock
 
 from sendto_silhouette import SendtoSilhouette, __version__
+from render_silhouette_regmarks import InsertRegmark
 from inkex import Transform
 from inkex.tester import TestCase
 from inkex.tester.mock import Capture
@@ -447,6 +448,27 @@ class MultiPageTest(SendtoSilhouetteTest):
         self.assertEqual(self.e.reg_origin_Y, 10)
         self.assertEqual(self.e.reg_width, 190)
         self.assertEqual(self.e.reg_length, 277)
+
+
+class GeneratedMultiPageRegmarksTest(SendtoSilhouetteTest):
+    source_file = "multipage_pages.svg"
+
+    def test_page_groups_are_detected_inside_the_regmark_layer(self):
+        renderer = InsertRegmark()
+        renderer.parse_arguments([self.data_file(self.source_file)])
+        renderer.load_raw()
+        renderer.effect()
+        renderer.clean_up()
+
+        self.e.parse_arguments([self.data_file(self.source_file)])
+        self.e.svg = renderer.svg
+        self.e.document = renderer.document
+        self.assertEqual(
+            self.e.page_regmark_settings(0), (10, 10, 190, 277)
+        )
+        self.assertEqual(
+            self.e.page_regmark_settings(1), (10, 10, 190, 277)
+        )
 
 
 #@mark.xfail(__inkex_version__[0:3] < "1.2", reason="earlier versions generate other curves")

--- a/test/test_sendto_silhouette.py
+++ b/test/test_sendto_silhouette.py
@@ -407,6 +407,48 @@ class TransformTest(SendtoSilhouetteTest):
         )
 
 
+class MultiPageTest(SendtoSilhouetteTest):
+    source_file = "multipage_regmarks.svg"
+
+    def load_page_paths(self, *element_ids):
+        self.e.parse_arguments([self.data_file(self.source_file)])
+        self.e.load_raw()
+        self.e.clean_up()
+        self.e.initDocScale()
+        for element_id in element_ids:
+            self.e.recursivelyTraverseSvg([
+                self.e.svg.getElementById(element_id)
+            ])
+        self.e.sync_page_settings()
+
+    def test_second_page_path_is_converted_to_page_local_coordinates(self):
+        self.load_page_paths("page2-cut")
+
+        self.assertDeepAlmostEqual(
+            self.e.paths,
+            [[(20, 40), (40, 40), (40, 60), (20, 60), (20, 40)]],
+        )
+        self.assertEqual(self.e.active_page_indices, [1])
+        self.assertAlmostEqual(self.e.media_width_mm, 210)
+        self.assertAlmostEqual(self.e.media_height_mm, 297)
+
+    def test_paths_on_multiple_pages_are_normalized_independently(self):
+        self.load_page_paths("page1-cut", "page2-cut")
+
+        expected = [(20, 40), (40, 40), (40, 60), (20, 60), (20, 40)]
+        self.assertDeepAlmostEqual(self.e.paths, [expected, expected])
+        self.assertEqual(self.e.active_page_indices, [0, 1])
+
+    def test_registration_marks_are_detected_on_selected_page(self):
+        self.load_page_paths("page2-cut")
+        self.e.sync_regmark_settings()
+
+        self.assertEqual(self.e.reg_origin_X, 10)
+        self.assertEqual(self.e.reg_origin_Y, 10)
+        self.assertEqual(self.e.reg_width, 190)
+        self.assertEqual(self.e.reg_length, 277)
+
+
 #@mark.xfail(__inkex_version__[0:3] < "1.2", reason="earlier versions generate other curves")
 class CurvesTest(SendtoSilhouetteTest):
     source_file = "curved_dashes.test.svg"


### PR DESCRIPTION
## Summary

Add full multi-page Inkscape document support.

- Normalize cuts from each page into page-local cutter coordinates.
- Render a separate `Regmarks (page N)` layer on every page.
- Use the selected page's media and registration-mark geometry when cutting.
- Reject selections that span incompatible page or registration-mark sizes.

## Why

Inkscape stores multi-page artwork on one shared canvas. Without page-aware handling, later-page cuts retain their canvas offset and registration marks are only generated for one page.

## Validation

- `PYTHONPATH=/private/tmp/inkscape-silhouette-inkex-min python3 -m pytest -q test/test_sendto_silhouette.py test/test_render_silhouette_regmark.py`
  - 33 passed.
- Verified the multi-page SVG fixture is well-formed XML.
